### PR TITLE
Hotfix: format units

### DIFF
--- a/src/utilities/reduceAddNum.ts
+++ b/src/utilities/reduceAddNum.ts
@@ -1,3 +1,3 @@
-const reduceAddNum = (acc: any, a: any) => acc + a
+const reduceAddNum = (acc: number, a: number) => acc + Number(a)
 
 export default reduceAddNum


### PR DESCRIPTION
values returned from validator cache are now strings, changed hooks equations to account for the new format