### PR TITLE
CI: publish docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,6 @@ on:
         branches:
             - unstable
             - stable
-            - ci-publish-docker
         tags:
             - v*
 
@@ -34,11 +33,6 @@ jobs:
               run: |
                     echo "VERSION=latest" >> $GITHUB_ENV
                     echo "VERSION_SUFFIX=-unstable" >> $GITHUB_ENV
-            - name: Extract version (if publish-test)
-              if: github.event.ref == 'refs/heads/ci-publish-docker'
-              run: |
-                    echo "VERSION=latest" >> $GITHUB_ENV
-                    echo "VERSION_SUFFIX=-test" >> $GITHUB_ENV
             - name: Extract version (if tagged release)
               if: startsWith(github.event.ref, 'refs/tags')
               run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -98,7 +98,7 @@ jobs:
             - name: Create and push multiarch manifest
               run: |
                   docker manifest create ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX} \
-                      --amend ${IMAGE_NAME}:${VERSION}-arm64${VERSION_SUFFIX} matrix.modernity }} \
-                      --amend ${IMAGE_NAME}:${VERSION}-amd64${VERSION_SUFFIX} matrix.modernity }};
+                      --amend ${IMAGE_NAME}:${VERSION}-arm64${VERSION_SUFFIX} \
+                      --amend ${IMAGE_NAME}:${VERSION}-amd64${VERSION_SUFFIX};
                   docker manifest push ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,104 @@
+name: docker
+
+on:
+    push:
+        branches:
+            - unstable
+            - stable
+            - ci-publish-docker
+        tags:
+            - v*
+
+env:
+    DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+    DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+    IMAGE_NAME: ${{ github.repository_owner}}/siren
+
+jobs:
+    # Extract the VERSION which is either `latest` or `vX.Y.Z`, and the VERSION_SUFFIX
+    # which is either empty or `-unstable`.
+    #
+    # It would be nice if the arch didn't get spliced into the version between `latest` and
+    # `unstable`, but for now we keep the two parts of the version separate for backwards
+    # compatibility.
+    extract-version:
+        runs-on: ubuntu-22.04
+        steps:
+            - name: Extract version (if stable)
+              if: github.event.ref == 'refs/heads/stable'
+              run: |
+                    echo "VERSION=latest" >> $GITHUB_ENV
+                    echo "VERSION_SUFFIX=" >> $GITHUB_ENV
+            - name: Extract version (if unstable)
+              if: github.event.ref == 'refs/heads/unstable'
+              run: |
+                    echo "VERSION=latest" >> $GITHUB_ENV
+                    echo "VERSION_SUFFIX=-unstable" >> $GITHUB_ENV
+            - name: Extract version (if publish-test)
+              if: github.event.ref == 'refs/heads/ci-publish-docker'
+              run: |
+                    echo "VERSION=latest" >> $GITHUB_ENV
+                    echo "VERSION_SUFFIX=-test" >> $GITHUB_ENV
+            - name: Extract version (if tagged release)
+              if: startsWith(github.event.ref, 'refs/tags')
+              run: |
+                    echo "VERSION=$(echo ${GITHUB_REF#refs/tags/})" >> $GITHUB_ENV
+                    echo "VERSION_SUFFIX=" >> $GITHUB_ENV
+        outputs:
+            VERSION: ${{ env.VERSION }}
+            VERSION_SUFFIX: ${{ env.VERSION_SUFFIX }}
+    build-docker-single-arch:
+        name: build-docker-${{ matrix.binary }}
+        runs-on: ubuntu-22.04
+        strategy:
+            matrix:
+                binary: [aarch64, x86_64]
+
+        needs: [extract-version]
+        env:
+            # We need to enable experimental docker features in order to use `docker buildx`
+            DOCKER_CLI_EXPERIMENTAL: enabled
+            VERSION: ${{ needs.extract-version.outputs.VERSION }}
+            VERSION_SUFFIX: ${{ needs.extract-version.outputs.VERSION_SUFFIX }}
+        steps:
+            - uses: actions/checkout@v3
+            - name: Dockerhub login
+              run: |
+                  echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
+            - name: Map aarch64 to arm64 short arch
+              if: startsWith(matrix.binary, 'aarch64')
+              run: echo "SHORT_ARCH=arm64" >> $GITHUB_ENV
+            - name: Map x86_64 to amd64 short arch
+              if: startsWith(matrix.binary, 'x86_64')
+              run: echo "SHORT_ARCH=amd64" >> $GITHUB_ENV;
+            # Install dependencies for emulation. Have to create a new builder to pick up emulation support.
+            - name: Build Dockerfile and push
+              run: |
+                  docker run --privileged --rm tonistiigi/binfmt --install ${SHORT_ARCH}
+                  docker buildx create --use --name cross-builder
+                  docker buildx build \
+                      --platform=linux/${SHORT_ARCH} \
+                      --file ./Dockerfile . \
+                      --tag ${IMAGE_NAME}:${VERSION}-${SHORT_ARCH}${VERSION_SUFFIX} \
+                      --provenance=false \
+                      --push
+    build-docker-multiarch:
+        name: build-docker-multiarch
+        runs-on: ubuntu-22.04
+        needs: [build-docker-single-arch, extract-version]
+        env:
+            # We need to enable experimental docker features in order to use `docker manifest`
+            DOCKER_CLI_EXPERIMENTAL: enabled
+            VERSION: ${{ needs.extract-version.outputs.VERSION }}
+            VERSION_SUFFIX: ${{ needs.extract-version.outputs.VERSION_SUFFIX }}
+        steps:
+            - name: Dockerhub login
+              run: |
+                  echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
+            - name: Create and push multiarch manifest
+              run: |
+                  docker manifest create ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX} \
+                      --amend ${IMAGE_NAME}:${VERSION}-arm64${VERSION_SUFFIX} matrix.modernity }} \
+                      --amend ${IMAGE_NAME}:${VERSION}-amd64${VERSION_SUFFIX} matrix.modernity }};
+                  docker manifest push ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX}
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,6 +62,7 @@ jobs:
             VERSION_SUFFIX: ${{ needs.extract-version.outputs.VERSION_SUFFIX }}
         steps:
             - uses: actions/checkout@v3
+            - uses: docker/setup-qemu-action@v2
             - name: Dockerhub login
               run: |
                   echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
@@ -74,8 +75,6 @@ jobs:
             # Install dependencies for emulation. Have to create a new builder to pick up emulation support.
             - name: Build Dockerfile and push
               run: |
-                  docker run --privileged --rm tonistiigi/binfmt --install ${SHORT_ARCH}
-                  docker buildx create --use --name cross-builder
                   docker buildx build \
                       --platform=linux/${SHORT_ARCH} \
                       --file ./Dockerfile . \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ COPY . /app/
 WORKDIR /app
 
 ENV NODE_ENV=development
+
+# cross-builds timeout on downloading deps for some reason
+RUN yarn config set network-timeout 300000
+
 # install (dev) deps
 RUN yarn
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,9 @@ WORKDIR /app
 
 ENV NODE_ENV=development
 
-# cross-builds timeout on downloading deps for some reason
-RUN yarn config set network-timeout 300000
-
 # install (dev) deps
-RUN yarn
+# on GitHub runners, timeouts occur in emulated containers
+RUN yarn --network-timeout 300000
 
 ENV NODE_ENV=production
 # build (prod) app


### PR DESCRIPTION
the aarch64 build is excruuuuciatingly slow but hey it works 🤷‍♂️

right now, docker images are pushed to the [sigmaprime](https://hub.docker.com/u/sigmaprime) repo that we use for devops stuff.  
the `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets in this repo need to be changed towards our `sigp` account for proper releases. 