### PR TITLE
upload signatures right next to binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,23 +130,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: siren-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.zip.asc
-          path: artifacts/siren-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.zip.asc
-
-  #            - name: Upload signature (aarch64-unknown-linux-gnu)
-  #              uses: actions/upload-artifact@v3
-  #              with:
-  #                name: siren-${{ needs.extract-version.outputs.VERSION }}-aarch64-unknown-linux-gnu.zip.asc
-  #                path: artifacts//siren-${{ needs.extract-version.outputs.VERSION }}-aarch64-unknown-linux-gnu.zip.asc
-  #            - name: Upload signature (x86_64-unknown-linux-gnu)
-  #              uses: actions/upload-artifact@v3
-  #              with:
-  #                name: siren-${{ needs.extract-version.outputs.VERSION }}-x86_64-unknown-linux-gnu.zip.asc
-  #                path: artifacts/siren-${{ needs.extract-version.outputs.VERSION }}-x86_64-unknown-linux-gnu.zip.asc
-  #            - name: Upload signature (x86_64-windows)
-  #              uses: actions/upload-artifact@v3
-  #              with:
-  #                name: siren-${{ needs.extract-version.outputs.VERSION }}-x86_64-windows.zip.asc
-  #                path: artifacts/siren-${{ needs.extract-version.outputs.VERSION }}-x86_64-windows.zip.asc
+          path: ./siren-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.zip.asc
 
   draft-release:
     name: Draft Release


### PR DESCRIPTION
the signatures weren't getting picked up for the draft release because they were at `./artifacts/<file>` instead of `./<file>` 