### PR TITLE
add error handling to startup logic

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+backend/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ FROM $node_image AS builder
 
 COPY . /app/
 
-ENV NEXT_TELEMETRY_DISABLED=1
-ENV NODE_ENV=development
+ENV NEXT_TELEMETRY_DISABLED=1 \
+    NODE_ENV=development
 
 WORKDIR /app
 RUN yarn --network-timeout 300000
@@ -27,7 +27,9 @@ ENV NODE_ENV=production
 RUN npm install --global pm2
 RUN apk add -U nginx openssl
 
+COPY ./.env.example /app/
 COPY ./docker-assets /app/docker-assets/
+
 RUN rm /etc/nginx/http.d/default.conf; \
     ln -s /app/docker-assets/siren-http.conf /etc/nginx/http.d/siren-http.conf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,44 +3,41 @@ ARG node_image=node:${node_version}
 
 FROM $node_image AS builder
 
-COPY . /app/
-
 ENV NEXT_TELEMETRY_DISABLED=1 \
     NODE_ENV=development
-
 WORKDIR /app
-RUN yarn --network-timeout 300000
+COPY . /app/
+
+RUN yarn --network-timeout 300000; \
+    NODE_ENV=production yarn build
 WORKDIR /app/backend
-RUN yarn --network-timeout 300000
+RUN yarn --network-timeout 300000; \
+    NODE_ENV=production yarn build
 
-ENV NODE_ENV=production 
-
-RUN yarn build 
-WORKDIR /app
-RUN yarn build
-
-FROM node:${node_version}-alpine AS production
-
-WORKDIR /app
-
-ENV NODE_ENV=production
-RUN npm install --global pm2
-RUN apk add -U nginx openssl
+FROM alpine AS intermediate
 
 COPY ./.env.example /app/
 COPY ./docker-assets /app/docker-assets/
-
-RUN rm /etc/nginx/http.d/default.conf; \
-    ln -s /app/docker-assets/siren-http.conf /etc/nginx/http.d/siren-http.conf
 
 COPY --from=builder /app/backend/package.json /app/backend/package.json
 COPY --from=builder /app/backend/node_modules /app/backend/node_modules
 COPY --from=builder /app/backend/dist /app/backend/dist
 
-COPY --from=builder /app/siren.js /app/siren.js
-COPY --from=builder /app/package.json /app/package.json
+COPY --from=builder /app/siren.js /app/package.json /app/
 COPY --from=builder /app/node_modules /app/node_modules
 COPY --from=builder /app/public /app/public
 COPY --from=builder /app/.next /app/.next
+
+
+FROM node:${node_version}-alpine AS production
+
+ENV NODE_ENV=production
+RUN npm install --global pm2; \
+    apk add -U nginx openssl curl
+
+RUN rm /etc/nginx/http.d/default.conf; \
+    ln -s /app/docker-assets/siren-http.conf /etc/nginx/http.d/siren-http.conf
+
+COPY --from=intermediate /app /app/
 
 ENTRYPOINT /app/docker-assets/docker-entrypoint.sh

--- a/docker-assets/docker-entrypoint.sh
+++ b/docker-assets/docker-entrypoint.sh
@@ -1,5 +1,17 @@
 #!/bin/ash
 
+# if no .env found, dump the default to stdout and exit
+if [ ! -f /app/.env ]
+then
+  printf "No \`/.env\` file found at the expected location (\`/app/.env\`). \n\
+Please adapt this default file to your needs and mount it within the container: \n\
+----------------\n"
+  cat /app/.env.example
+  printf "----------------\n"
+  exit 1
+fi
+
+# load .env 
 set -a; \
 . /app/.env; \
 set +a
@@ -11,14 +23,17 @@ if [ $SSL_ENABLED = true ] ; then
     openssl req -x509 -newkey rsa:4096 -keyout /certs/key.pem -out /certs/cert.pem -days 365 -passout pass:'sigmaprime' -subj "/C=AU/CN=siren/emailAddress=noreply@sigmaprime.io"
     echo 'sigmaprime' > /certs/key.pass
   fi
-  ## nginx ssl stuff
-    ln -s /app/docker-assets/siren-https.conf /etc/nginx/http.d/siren-https.conf
+  ln -s /app/docker-assets/siren-https.conf /etc/nginx/http.d/siren-https.conf
 fi
 
-nginx &
 
+# test config, start nginx 
+nginx -t && nginx &
+
+# start backend
 cd /app/backend
 PM2_HOME='~/.pm2-backend' pm2-runtime yarn --interpreter sh -- start:prod &
 
+# start frontend
 cd /app
 PM2_HOME='~/.pm2-frontend' pm2-runtime yarn --interpreter sh -- start 

--- a/docker-assets/docker-entrypoint.sh
+++ b/docker-assets/docker-entrypoint.sh
@@ -28,7 +28,7 @@ done
 # check api token
 api_response_code=$(curl -sIX GET "${VALIDATOR_URL:-http://127.0.0.1}/lighthouse/version" -H "Authorization: Bearer ${API_TOKEN:-default_siren_token}" | head -n 1 | awk '{print $2}')
 if [ "$api_response_code" != '200' ]; then
-  printf "validator api issue, server response: $api_response_code\n"  
+  printf "validator api issue, server response: %s \n" "${api_response_code:-no_response}"  
   fail=true
 fi
 


### PR DESCRIPTION
solves a couple issues on #238 : namely 
- provide default .env file if none provided
- better error handling on startup (i.e., APIs unavailable)

additionally, the final docker image is cleaner (less layers) 