### PR TITLE
Move from `.env` file to env vars (with defaults builtin)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
 BEACON_URL=http://your-BN-ip:5052
 VALIDATOR_URL=http://your-VC-ip:5062
-API_TOKEN="get-it-from-'.lighthouse/validators/api-token.txt'"
-SESSION_PASSWORD="default-siren-password"
+API_TOKEN=get-it-from-'.lighthouse/validators/api-token.txt'
+SESSION_PASSWORD=default-siren-password
 SSL_ENABLED=true
-# don't change these when building the docker image
+# don't change these when building the docker image, only change when running outside of docker
 PORT=3000
 BACKEND_URL=http://127.0.0.1:3001

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 BEACON_URL=http://your-BN-ip:5052
 VALIDATOR_URL=http://your-VC-ip:5062
 API_TOKEN="get-it-from-'.lighthouse/validators/api-token.txt'"
-SESSION_PASSWORD="your-password"
+SESSION_PASSWORD="default-siren-password"
 SSL_ENABLED=true
 # don't change these when building the docker image
 PORT=3000

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
-PORT=3000
-BACKEND_URL=http://127.0.0.1:3001
 BEACON_URL=http://your-BN-ip:5052
 VALIDATOR_URL=http://your-VC-ip:5062
-API_TOKEN=get-it-from-'.lighthouse/validators/api-token.txt'
+API_TOKEN="get-it-from-'.lighthouse/validators/api-token.txt'"
 SESSION_PASSWORD="your-password"
 SSL_ENABLED=true
+# don't change these when building the docker image
+PORT=3000
+BACKEND_URL=http://127.0.0.1:3001

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN yarn --network-timeout 300000; \
 
 FROM alpine AS intermediate
 
-COPY ./.env.example /app/
 COPY ./docker-assets /app/docker-assets/
 
 COPY --from=builder /app/backend/package.json /app/backend/package.json

--- a/docker-assets/docker-entrypoint.sh
+++ b/docker-assets/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 # configure default vars if none provided
 set -a 
 PORT=${PORT:-3000}
-BACKEND_URL=${BACKEND_URLs:-=http://127.0.0.1:3001}
+BACKEND_URL=${BACKEND_URL:-=http://127.0.0.1:3001}
 BEACON_URL=${BEACON_URL:-http://your-BN-ip:5052}
 VALIDATOR_URL=${VALIDATOR_URL:-http://your-VC-ip:5062}
 API_TOKEN=${API_TOKEN:-"get-it-from-'.lighthouse/validators/api-token.txt'"}

--- a/docker-assets/docker-entrypoint.sh
+++ b/docker-assets/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 # configure default vars if none provided
 set -a 
 PORT=${PORT:-3000}
-BACKEND_URL=${BACKEND_URL:-=http://127.0.0.1:3001}
+BACKEND_URL=${BACKEND_URL:-http://127.0.0.1:3001}
 BEACON_URL=${BEACON_URL:-http://your-BN-ip:5052}
 VALIDATOR_URL=${VALIDATOR_URL:-http://your-VC-ip:5062}
 API_TOKEN=${API_TOKEN:-"get-it-from-'.lighthouse/validators/api-token.txt'"}

--- a/docker-assets/docker-entrypoint.sh
+++ b/docker-assets/docker-entrypoint.sh
@@ -1,23 +1,18 @@
 #!/bin/ash
 
-# if no .env found, dump the default to stdout and exit
-if [ ! -f /app/.env ]
-then
-  printf "No \`/.env\` file found at the expected location (\`/app/.env\`). \n\
-Please adapt this default file to your needs and mount it within the container: \n\
-----------------\n"
-  cat /app/.env.example
-  printf "----------------\n"
-  exit 1
-fi
-
-# load .env 
-set -a; \
-. /app/.env; \
+# configure default vars if none provided
+set -a 
+PORT=${PORT:-3000}
+BACKEND_URL=${BACKEND_URLs:-=http://127.0.0.1:3001}
+BEACON_URL=${BEACON_URL:-http://your-BN-ip:5052}
+VALIDATOR_URL=${VALIDATOR_URL:-http://your-VC-ip:5062}
+API_TOKEN=${API_TOKEN:-"get-it-from-'.lighthouse/validators/api-token.txt'"}
+SESSION_PASSWORD=${SESSION_PASSWORD:-default-siren-password}
+SSL_ENABLED=${SSL_ENABLED:-true}
 set +a
 
 # if bn/vc api unreachable, print message and exit
-tests="${BEACON_URL:-http://your-BN-ip:5052} ${VALIDATOR_URL:-http://your-VC-ip:5062}"
+tests="${BEACON_URL} ${VALIDATOR_URL}"
 for test in $tests; do 
   nc -z "${test#*//}"
   if [ $? -eq 1 ]; then
@@ -26,7 +21,7 @@ for test in $tests; do
   fi
 done
 # check api token
-api_response_code=$(curl -sIX GET "${VALIDATOR_URL:-http://127.0.0.1}/lighthouse/version" -H "Authorization: Bearer ${API_TOKEN:-default_siren_token}" | head -n 1 | awk '{print $2}')
+api_response_code=$(curl -sIX GET "${VALIDATOR_URL}/lighthouse/version" -H "Authorization: Bearer ${API_TOKEN}" | head -n 1 | awk '{print $2}')
 if [ "$api_response_code" != '200' ]; then
   printf "validator api issue, server response: %s \n" "${api_response_code:-no_response}"  
   fail=true


### PR DESCRIPTION
example: 
```
docker run --rm -ti --name siren -p 3443:443 \
-e VALIDATOR_URL=http://host.docker.internal:5062 \
-e BEACON_URL=http://host.docker.internal:5052 \
-e API_TOKEN="api-token-0xyourvalue" \
siren
```

this will also set and use the following default values:
```
SESSION_PASSWORD="default-siren-password"
SSL_ENABLED=true
PORT=3000
BACKEND_URL=http://127.0.0.1:3001
```