### PR TITLE
fix: proposer duties error response

### DIFF
--- a/backend/src/beacon/beacon.service.ts
+++ b/backend/src/beacon/beacon.service.ts
@@ -222,8 +222,8 @@ export class BeaconService {
       })
     }
      catch (e) {
-      console.error(e);
-      throwServerError('Unable to fetch proposer data');
+      console.error(e?.response?.data);
+      return [];
     }
   }
 


### PR DESCRIPTION
return empty array instead of throwing error for proposer-duties api requests