### PR TITLE
Rename auth variables

### DIFF
--- a/src/components/AuthPrompt/AuthPrompt.tsx
+++ b/src/components/AuthPrompt/AuthPrompt.tsx
@@ -47,7 +47,7 @@ const AuthPrompt:FC<AuthModalProps> = ({onSubmit, isVisible, isLoading, mode, on
                     control={control as any}
                     render={({ field: { ref: _ref, ...props }, fieldState }) => (
                       <Input
-                        label="User Name"
+                        label="Name"
                         uiMode={mode}
                         error={fieldState.error?.message}
                         {...props}
@@ -61,7 +61,7 @@ const AuthPrompt:FC<AuthModalProps> = ({onSubmit, isVisible, isLoading, mode, on
                   render={({ field: { ref: _ref, ...props }, fieldState }) => (
                     <Input
                       isAutoFocus
-                      label={isNamePrompt ? 'Password' : undefined}
+                      label={isNamePrompt ? 'Session Password' : undefined}
                       autoComplete="new-password"
                       type="password"
                       uiMode={mode}

--- a/src/components/AuthPrompt/AuthPrompt.tsx
+++ b/src/components/AuthPrompt/AuthPrompt.tsx
@@ -47,7 +47,7 @@ const AuthPrompt:FC<AuthModalProps> = ({onSubmit, isVisible, isLoading, mode, on
                     control={control as any}
                     render={({ field: { ref: _ref, ...props }, fieldState }) => (
                       <Input
-                        label="Name"
+                        label={t('authPrompt.label.name')}
                         uiMode={mode}
                         error={fieldState.error?.message}
                         {...props}
@@ -61,7 +61,7 @@ const AuthPrompt:FC<AuthModalProps> = ({onSubmit, isVisible, isLoading, mode, on
                   render={({ field: { ref: _ref, ...props }, fieldState }) => (
                     <Input
                       isAutoFocus
-                      label={isNamePrompt ? 'Session Password' : undefined}
+                      label={isNamePrompt ? t('authPrompt.label.sessionPassword') : undefined}
                       autoComplete="new-password"
                       type="password"
                       uiMode={mode}

--- a/src/components/AuthPrompt/AuthPrompt.tsx
+++ b/src/components/AuthPrompt/AuthPrompt.tsx
@@ -1,7 +1,7 @@
 import { FC, useState } from 'react';
 import { Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import Lighthouse from '../../assets/images/lightHouse.svg'
+import Lighthouse from '../../assets/images/lightHouse.svg';
 import { UiMode } from '../../constants/enums';
 import AuthenticationForm, { AuthFormProps } from '../../forms/AuthenticationForm';
 import AnimatedHeader from '../AnimatedHeader/AnimatedHeader';
@@ -47,6 +47,9 @@ const AuthPrompt:FC<AuthModalProps> = ({onSubmit, isVisible, isLoading, mode, on
                     control={control as any}
                     render={({ field: { ref: _ref, ...props }, fieldState }) => (
                       <Input
+                        tooltip={t('authPrompt.tooltip.displayName')}
+                        toolTipId="displayName"
+                        toolTipMode={UiMode.LIGHT}
                         label={t('authPrompt.label.name')}
                         uiMode={mode}
                         error={fieldState.error?.message}
@@ -61,6 +64,8 @@ const AuthPrompt:FC<AuthModalProps> = ({onSubmit, isVisible, isLoading, mode, on
                   render={({ field: { ref: _ref, ...props }, fieldState }) => (
                     <Input
                       isAutoFocus
+                      tooltip={t('authPrompt.tooltip.sessionPassword')}
+                      toolTipId="sessionPassword"
                       label={isNamePrompt ? t('authPrompt.label.sessionPassword') : undefined}
                       autoComplete="new-password"
                       type="password"

--- a/src/components/ValidatorGraffiti/ValidatorGraffiti.tsx
+++ b/src/components/ValidatorGraffiti/ValidatorGraffiti.tsx
@@ -77,7 +77,7 @@ const ValidatorGraffiti:FC<ValidatorGraffitiProps> = ({validator}) => {
 
   return (
     <>
-      <AuthPrompt isLoading={isLoading} mode={mode} onClose={closeAuth} isVisible={isAuth} onSubmit={updateGraffiti} />
+      <AuthPrompt isLoading={isLoading} maxHeight="400px" mode={mode} onClose={closeAuth} isVisible={isAuth} onSubmit={updateGraffiti} />
       <ValidatorGraffitiInput isLoading={isLoading} onSubmit={storeGraffitiInput} value={graffiti} />
     </>
   )

--- a/src/locales/translations/en-US.json
+++ b/src/locales/translations/en-US.json
@@ -481,7 +481,11 @@
     "noPasswordFound": "No Session Password found",
     "invalidPassword": "Invalid password. Please try again.",
     "unableToReach": "Unable to reach backend.",
-    "defaultErrorMessage": "Error reaching backend server..."
+    "defaultErrorMessage": "Error reaching backend server...",
+    "label": {
+      "name": "Name",
+      "sessionPassword": "Session Password"
+    }
   },
   "errorPage": {
     "title": "Opps!",

--- a/src/locales/translations/en-US.json
+++ b/src/locales/translations/en-US.json
@@ -482,6 +482,10 @@
     "invalidPassword": "Invalid password. Please try again.",
     "unableToReach": "Unable to reach backend.",
     "defaultErrorMessage": "Error reaching backend server...",
+    "tooltip": {
+      "displayName": "Display name for the Siren dashboard",
+      "sessionPassword": "Required password set in the configuration file"
+    },
     "label": {
       "name": "Name",
       "sessionPassword": "Session Password"


### PR DESCRIPTION
Changes the name of some auth variables to make it less confusing about what to enter. 


I think we should add some tooltips to explain this, but I wasn't sure how to do it :p 