### PR TITLE
Fix/paginate priority

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -54,6 +54,7 @@
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",
     "@types/cookie-parser": "^1.4.7",
+    "@types/eventsource": "^1.1.15",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",
     "@types/node": "^20.3.1",

--- a/backend/src/activity/activity.controller.ts
+++ b/backend/src/activity/activity.controller.ts
@@ -13,6 +13,7 @@ import {
 import { ActivityService } from './activity.service';
 import { SessionGuard } from '../session.guard';
 import { Request, Response } from 'express';
+import { KEEP_ALIVE_MESSAGE, SSE_HEADER } from '../../../src/constants/sse';
 
 @Controller('activity')
 @UseGuards(SessionGuard)
@@ -42,19 +43,14 @@ export class ActivityController {
 
   @Get('stream')
   sse(@Req() req: Request, @Res() res: Response) {
-    res.writeHead(200, {
-      'Content-Type': 'text/event-stream',
-      'Cache-Control': 'no-cache',
-      Connection: 'keep-alive',
-      'X-Accel-Buffering': 'no',
-    });
+    res.writeHead(200, SSE_HEADER);
 
     res.flushHeaders();
 
     this.activityService.addClient(res);
 
     const heartbeatInterval = setInterval(() => {
-      res.write(': keep-alive\n\n');
+      res.write(KEEP_ALIVE_MESSAGE);
     }, 10000);
 
     req.on('close', () => {

--- a/backend/src/activity/activity.service.ts
+++ b/backend/src/activity/activity.service.ts
@@ -4,6 +4,7 @@ import { Activity } from './entities/activity.entity';
 import { ActivityType } from '../../../src/types';
 import { UpdateOptions, Op } from 'sequelize';
 import { Response } from 'express';
+import { ClientManager } from '../utils/client-manager';
 
 @Injectable()
 export class ActivityService {
@@ -12,19 +13,18 @@ export class ActivityService {
     private activityRepository: typeof Activity,
   ) {}
 
-  private clients: Response[] = [];
+  private clientManager = new ClientManager();
 
   public addClient(client: Response) {
-    this.clients.push(client);
+    this.clientManager.addClient(client);
   }
 
   public removeClient(client: Response) {
-    this.clients = this.clients.filter((c) => c !== client);
+    this.clientManager.removeClient(client);
   }
 
   public sendMessageToClients(data: any) {
-    const message = `data: ${JSON.stringify(data)}\n\n`;
-    this.clients.forEach((client) => client.write(message));
+    this.clientManager.sendMessageToClients(data);
   }
 
   public async storeActivity(data: string, pubKey: string, type: ActivityType) {

--- a/backend/src/logs/logs.controller.ts
+++ b/backend/src/logs/logs.controller.ts
@@ -1,8 +1,8 @@
-// src/logs/logs.controller.ts
 import { Controller, Get, Res, Req, Param, UseGuards } from '@nestjs/common';
 import { Request, Response } from 'express';
 import { LogsService } from './logs.service';
 import { SessionGuard } from '../session.guard';
+import { KEEP_ALIVE_MESSAGE, SSE_HEADER } from '../../../src/constants/sse';
 
 @Controller('logs')
 @UseGuards(SessionGuard)
@@ -24,6 +24,25 @@ export class LogsController {
   @Get('metrics')
   getLogMetrics() {
     return this.logsService.readLogMetrics();
+  }
+
+  @Get('priority-log-stream')
+  sse(@Req() req: Request, @Res() res: Response) {
+    res.writeHead(200, SSE_HEADER);
+
+    res.flushHeaders();
+
+    this.logsService.addClient(res);
+
+    const heartbeatInterval = setInterval(() => {
+      res.write(KEEP_ALIVE_MESSAGE);
+    }, 10000);
+
+    req.on('close', () => {
+      clearInterval(heartbeatInterval);
+      this.logsService.removeClient(res);
+      res.end();
+    });
   }
 
   @Get('dismiss/:index')

--- a/backend/src/logs/logs.service.ts
+++ b/backend/src/logs/logs.service.ts
@@ -6,6 +6,7 @@ import { LogLevels, LogType, SSELog } from '../../../src/types';
 import { InjectModel } from '@nestjs/sequelize';
 import { Log } from './entities/log.entity';
 import { Op } from 'sequelize';
+import { ClientManager } from '../utils/client-manager';
 
 @Injectable()
 export class LogsService {
@@ -20,6 +21,20 @@ export class LogsService {
 
   private sseStreams: Map<string, Subject<any>> = new Map();
 
+  private clientManager = new ClientManager();
+
+  public addClient(client: Response) {
+    this.clientManager.addClient(client);
+  }
+
+  public removeClient(client: Response) {
+    this.clientManager.removeClient(client);
+  }
+
+  public sendMessageToClients(data: any) {
+    this.clientManager.sendMessageToClients(data);
+  }
+
   public async startSse(url: string, type: LogType) {
     console.log(`starting sse ${url}, ${type}...`);
     const eventSource = new EventSource(url);
@@ -27,7 +42,7 @@ export class LogsService {
     const sseStream: Subject<any> = new Subject();
     this.sseStreams.set(url, sseStream);
 
-    eventSource.onmessage = (event) => {
+    eventSource.onmessage = async (event) => {
       let newData;
 
       try {
@@ -39,10 +54,13 @@ export class LogsService {
       const { level } = newData;
 
       if (level !== LogLevels.INFO) {
-        this.logRepository.create(
+        const result = (await this.logRepository.create(
           { type, level, data: JSON.stringify(newData), isHidden: false },
           { ignoreDuplicates: true },
-        );
+        )) as any;
+
+        this.sendMessageToClients(result.dataValues);
+
         if (this.isDebug) {
           console.log(
             newData,

--- a/backend/src/utils/client-manager.ts
+++ b/backend/src/utils/client-manager.ts
@@ -1,0 +1,18 @@
+import { Response } from 'express';
+
+export class ClientManager {
+  private clients: Response[] = [];
+
+  public addClient(client: Response): void {
+    this.clients.push(client);
+  }
+
+  public removeClient(client: Response): void {
+    this.clients = this.clients.filter((c) => c !== client);
+  }
+
+  public sendMessageToClients(data: any): void {
+    const message = `data: ${JSON.stringify(data)}\n\n`;
+    this.clients.forEach((client) => client.write(message));
+  }
+}

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -1068,6 +1068,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
 
+"@types/eventsource@^1.1.15":
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/@types/eventsource/-/eventsource-1.1.15.tgz#949383d3482e20557cbecbf3b038368d94b6be27"
+  integrity sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA==
+
 "@types/express-serve-static-core@^4.17.33":
   version "4.19.0"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.19.0.tgz#3ae8ab3767d98d0b682cda063c3339e1e86ccfaa"
@@ -6049,6 +6054,7 @@ wkx@^0.5.0:
     "@types/node" "*"
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@types/jest": "^29.5.12",
     "@types/js-cookie": "^3.0.6",
     "@types/jsonwebtoken": "^9.0.6",
-    "@types/react": "18.3.12",
+    "@types/react": "19.0.2",
     "@uiw/react-textarea-code-editor": "^2.1.1",
     "autoprefixer": "^10.4.19",
     "axios": "^0.27.2",
@@ -85,7 +85,7 @@
     ]
   },
   "devDependencies": {
-    "@types/node": "22.10.1",
+    "@types/node": "22.10.2",
     "@typescript-eslint/eslint-plugin": "^7.1.0",
     "eslint": "8.57.0",
     "eslint-config-next": "^15.0.3",

--- a/siren.js
+++ b/siren.js
@@ -62,6 +62,9 @@ const handleSSe = (res, req, url) => {
 app.prepare().then(() => {
   const server = express()
   server.get('/activity-stream', (req, res) => handleSSe(res, req, `${backendUrl}/activity/stream`))
+  server.get('/priority-log-stream', (req, res) =>
+    handleSSe(res, req, `${backendUrl}/logs/priority-log-stream`),
+  )
   server.get('/validator-logs', (req, res) => handleSSe(res, req, `${backendUrl}/logs/validator`))
   server.get('/beacon-logs', (req, res) => handleSSe(res, req, `${backendUrl}/logs/beacon`))
 

--- a/src/components/AlertInfo/AlertInfo.tsx
+++ b/src/components/AlertInfo/AlertInfo.tsx
@@ -5,6 +5,7 @@ import sortAlertMessagesBySeverity from '../../../utilities/sortAlerts'
 import useDiagnosticAlerts from '../../hooks/useDiagnosticAlerts'
 import useDivDimensions from '../../hooks/useDivDimensions'
 import useMediaQuery from '../../hooks/useMediaQuery'
+import useSSEData from '../../hooks/useSSEData'
 import { proposerDuties } from '../../recoil/atoms'
 import { LogLevels, StatusColor } from '../../types'
 import AlertCard from '../AlertCard/AlertCard'
@@ -23,6 +24,14 @@ const AlertInfo: FC<AlertInfoProps> = ({ metrics, ...props }) => {
   const headerDimensions = useDivDimensions()
   const [filter, setFilter] = useState('all')
   const duties = useRecoilValue(proposerDuties)
+
+  const { data: streamedData } = useSSEData({
+    url: '/priority-log-stream',
+    isReady: true,
+    isStateStore: true,
+  })
+
+  console.log(streamedData)
 
   const priorityLogAlerts = useMemo(() => {
     return Object.values(metrics)

--- a/src/constants/sse.ts
+++ b/src/constants/sse.ts
@@ -1,0 +1,8 @@
+export const SSE_HEADER = {
+  'Content-Type': 'text/event-stream',
+  'Cache-Control': 'no-cache',
+  Connection: 'keep-alive',
+  'X-Accel-Buffering': 'no',
+}
+
+export const KEEP_ALIVE_MESSAGE = ': keep-alive\n\n'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2605,10 +2605,17 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.34.tgz#10964ba0dee6ac4cd462e2795b6bebd407303433"
   integrity sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==
 
-"@types/node@*", "@types/node@22.10.1":
+"@types/node@*":
   version "22.10.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.10.1.tgz#41ffeee127b8975a05f8c4f83fb89bcb2987d766"
   integrity sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==
+  dependencies:
+    undici-types "~6.20.0"
+
+"@types/node@22.10.2":
+  version "22.10.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.10.2.tgz#a485426e6d1fdafc7b0d4c7b24e2c78182ddabb9"
+  integrity sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==
   dependencies:
     undici-types "~6.20.0"
 
@@ -2641,12 +2648,19 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@18.3.12":
+"@types/react@*":
   version "18.3.12"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.12.tgz#99419f182ccd69151813b7ee24b792fe08774f60"
   integrity sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==
   dependencies:
     "@types/prop-types" "*"
+    csstype "^3.0.2"
+
+"@types/react@19.0.2":
+  version "19.0.2"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.0.2.tgz#9363e6b3ef898c471cb182dd269decc4afc1b4f6"
+  integrity sha512-USU8ZI/xyKJwFTpjSVIrSeHBVAGagkHQKPNbxeWwql/vDmnTIBgx+TJnhFnj1NXgz8XfprU0egV2dROLGpsBEg==
+  dependencies:
     csstype "^3.0.2"
 
 "@types/stack-utils@^2.0.0":


### PR DESCRIPTION
It is possible to have high amount of ERRO and CRIT logs while nodes are running. This can cause Siren to store a large amount of logs and slow down the api request, subsequently making the ssr first build slower when navigating to the main dashboard.

This pr resolves that buy creating a pagination effect for the priority logs displayed in the alerts component. By default Siren will fetch the most recent 15 logs and will allow the user to request via button. this prevents the first request from dumping 100s of logs and slowing down siren

https://github.com/sigp/siren/issues/251