### PR TITLE
Fix/paginate priority

### DIFF
--- a/app/api/log-metrics/route.ts
+++ b/app/api/log-metrics/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server'
+import getReqAuthToken from '../../../utilities/getReqAuthToken'
+import {fetchMetrics} from '../logs'
+
+export async function GET(req: Request) {
+  try {
+    const token = getReqAuthToken(req)
+    const data = await fetchMetrics(token)
+    return NextResponse.json(data)
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to fetch logs metrics' }, { status: 500 })
+  }
+}

--- a/app/api/logs.ts
+++ b/app/api/logs.ts
@@ -5,3 +5,25 @@ export const fetchLogMetrics = async (token: string) =>
   fetchFromApi(`${backendUrl}/logs/metrics`, token)
 export const dismissLogAlert = async (token: string, index: string) =>
   fetchFromApi(`${backendUrl}/logs/dismiss/${index}`, token)
+export const fetchMetrics = async (token: string) =>
+  fetchFromApi(`${backendUrl}/logs/log-metrics`, token)
+
+export interface fetchPriorityProps {
+  token: string
+  type?: string
+  limit?: string
+  order?: string
+  since?: string
+}
+
+export const fetchPriorityLogs = async (props: fetchPriorityProps) => {
+  const { token, type, limit, order, since } = props
+  const params = new URLSearchParams()
+
+  if (type) params.append('type', type)
+  if (limit) params.append('limit', limit)
+  if (order) params.append('order', order)
+  if (since) params.append('since', since)
+
+  return await fetchFromApi(`${backendUrl}/logs/priority-logs?${params.toString()}`, token)
+}

--- a/app/api/priority-logs/route.ts
+++ b/app/api/priority-logs/route.ts
@@ -1,11 +1,17 @@
 import { NextResponse } from 'next/server'
 import getReqAuthToken from '../../../utilities/getReqAuthToken'
-import { fetchLogMetrics } from '../logs'
+import {fetchPriorityLogs} from '../logs'
 
 export async function GET(req: Request) {
   try {
+    const { searchParams } = new URL(req.url)
+    const type = searchParams.get('type') || undefined
+    const limit = searchParams.get('limit') || undefined
+    const order = searchParams.get('order') || undefined
+    const since = searchParams.get('since') || undefined
+
     const token = getReqAuthToken(req)
-    const data = await fetchLogMetrics(token)
+    const data = await fetchPriorityLogs({token, type, limit, order, since})
     return NextResponse.json(data)
   } catch (error) {
     return NextResponse.json({ error: 'Failed to fetch priority logs' }, { status: 500 })

--- a/app/dashboard/Main.tsx
+++ b/app/dashboard/Main.tsx
@@ -17,7 +17,13 @@ import useLocalStorage from '../../src/hooks/useLocalStorage'
 import useNetworkMonitor from '../../src/hooks/useNetworkMonitor'
 import useSWRPolling from '../../src/hooks/useSWRPolling'
 import { exchangeRates, proposerDuties } from '../../src/recoil/atoms'
-import { ActivityResponse, LogMetric, ProposerDuty, StatusColor } from '../../src/types'
+import {
+  ActivityResponse,
+  LogData,
+  Metric,
+  ProposerDuty,
+  StatusColor
+} from '../../src/types'
 import { BeaconNodeSpecResults, SyncData } from '../../src/types/beacon'
 import { Diagnostics, PeerDataResults } from '../../src/types/diagnostic'
 import { ValidatorCache, ValidatorInclusionData, ValidatorInfo } from '../../src/types/validator'
@@ -35,8 +41,9 @@ export interface MainProps {
   initValCaches: ValidatorCache
   initInclusionRate: ValidatorInclusionData
   initProposerDuties: ProposerDuty[]
-  initLogMetrics: LogMetric
   initActivityData: ActivityResponse
+  initMetrics: Metric
+  initPriorityLogs: LogData[]
 }
 
 const Main: FC<MainProps> = (props) => {
@@ -52,8 +59,9 @@ const Main: FC<MainProps> = (props) => {
     lighthouseVersion,
     genesisTime,
     initProposerDuties,
-    initLogMetrics,
     initActivityData,
+    initMetrics,
+    initPriorityLogs
   } = props
 
   const { t } = useTranslation()
@@ -112,9 +120,9 @@ const Main: FC<MainProps> = (props) => {
     networkError,
   })
 
-  const { data: logMetrics } = useSWRPolling<LogMetric>('/api/priority-logs', {
+  const { data: metrics } = useSWRPolling<Metric>('/api/log-metrics', {
     refreshInterval: slotInterval / 2,
-    fallbackData: initLogMetrics,
+    fallbackData: initMetrics,
     networkError,
   })
 
@@ -123,7 +131,7 @@ const Main: FC<MainProps> = (props) => {
   const { isReady } = executionSync
   const { connected } = peerData
   const { natOpen } = nodeHealth
-  const warningCount = logMetrics.warningLogs?.length || 0
+  const warningCount = metrics.warningCount || 0
 
   useEffect(() => {
     setDuties((prev) => formatUniqueObjectArray([...prev, ...valDuties]))
@@ -252,7 +260,8 @@ const Main: FC<MainProps> = (props) => {
           />
           <ValidatorTable validators={validatorStates} className='mt-8 lg:mt-2' />
           <DiagnosticTable
-            metrics={logMetrics}
+            priorityLogs={initPriorityLogs}
+            logMetrics={metrics}
             bnSpec={beaconSpec}
             syncData={syncData}
             beanHealth={nodeHealth}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -11,7 +11,7 @@ import {
   fetchSyncData,
 } from '../api/beacon'
 import { fetchBeaconNodeVersion, fetchGenesisData, fetchValidatorVersion } from '../api/config'
-import { fetchLogMetrics } from '../api/logs'
+import {fetchMetrics, fetchPriorityLogs} from '../api/logs'
 import { fetchValCaches, fetchValStates } from '../api/validator'
 import Wrapper from './Wrapper'
 
@@ -30,8 +30,9 @@ export default async function Page() {
     const bnVersion = await fetchBeaconNodeVersion(token)
     const lighthouseVersion = await fetchValidatorVersion(token)
     const proposerDuties = await fetchProposerDuties(token)
-    const logMetrics = await fetchLogMetrics(token)
     const activities = await fetchActivities({ token })
+    const metrics = await fetchMetrics(token)
+    const priorityLogs = await fetchPriorityLogs({token})
 
     return (
       <Wrapper
@@ -43,11 +44,12 @@ export default async function Page() {
         initSyncData={syncData}
         initInclusionRate={inclusion}
         initPeerData={peerData}
-        initLogMetrics={logMetrics}
         genesisTime={genesisBlock}
         lighthouseVersion={lighthouseVersion.version}
         bnVersion={bnVersion.version}
         beaconSpec={beaconSpec}
+        initMetrics={metrics}
+        initPriorityLogs={priorityLogs}
       />
     )
   } catch (e) {

--- a/backend/package.json
+++ b/backend/package.json
@@ -54,6 +54,7 @@
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",
     "@types/cookie-parser": "^1.4.7",
+    "@types/eventsource": "^1.1.15",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",
     "@types/node": "^20.3.1",

--- a/backend/src/activity/activity.controller.ts
+++ b/backend/src/activity/activity.controller.ts
@@ -13,6 +13,7 @@ import {
 import { ActivityService } from './activity.service';
 import { SessionGuard } from '../session.guard';
 import { Request, Response } from 'express';
+import { KEEP_ALIVE_MESSAGE, SSE_HEADER } from '../../../src/constants/sse';
 
 @Controller('activity')
 @UseGuards(SessionGuard)
@@ -42,19 +43,14 @@ export class ActivityController {
 
   @Get('stream')
   sse(@Req() req: Request, @Res() res: Response) {
-    res.writeHead(200, {
-      'Content-Type': 'text/event-stream',
-      'Cache-Control': 'no-cache',
-      Connection: 'keep-alive',
-      'X-Accel-Buffering': 'no',
-    });
+    res.writeHead(200, SSE_HEADER);
 
     res.flushHeaders();
 
     this.activityService.addClient(res);
 
     const heartbeatInterval = setInterval(() => {
-      res.write(': keep-alive\n\n');
+      res.write(KEEP_ALIVE_MESSAGE);
     }, 10000);
 
     req.on('close', () => {

--- a/backend/src/activity/activity.service.ts
+++ b/backend/src/activity/activity.service.ts
@@ -65,16 +65,6 @@ export class ActivityService {
         }
       : undefined;
 
-    if (whereClause) {
-      return {
-        count: await this.activityRepository.count(),
-        rows: await this.activityRepository.findAll({
-          where: whereClause,
-          order: [['createdAt', orderQuery]],
-        }),
-      };
-    }
-
     return this.activityRepository.findAndCountAll({
       limit: queryLimit === 0 ? undefined : queryLimit,
       offset: Number(offset) || 0,

--- a/backend/src/activity/activity.service.ts
+++ b/backend/src/activity/activity.service.ts
@@ -4,6 +4,7 @@ import { Activity } from './entities/activity.entity';
 import { ActivityType } from '../../../src/types';
 import { UpdateOptions, Op } from 'sequelize';
 import { Response } from 'express';
+import { ClientManager } from '../utils/client-manager';
 
 @Injectable()
 export class ActivityService {
@@ -12,19 +13,18 @@ export class ActivityService {
     private activityRepository: typeof Activity,
   ) {}
 
-  private clients: Response[] = [];
+  private clientManager = new ClientManager();
 
   public addClient(client: Response) {
-    this.clients.push(client);
+    this.clientManager.addClient(client);
   }
 
   public removeClient(client: Response) {
-    this.clients = this.clients.filter((c) => c !== client);
+    this.clientManager.removeClient(client);
   }
 
   public sendMessageToClients(data: any) {
-    const message = `data: ${JSON.stringify(data)}\n\n`;
-    this.clients.forEach((client) => client.write(message));
+    this.clientManager.sendMessageToClients(data);
   }
 
   public async storeActivity(data: string, pubKey: string, type: ActivityType) {

--- a/backend/src/logs/logs.controller.ts
+++ b/backend/src/logs/logs.controller.ts
@@ -1,8 +1,8 @@
-// src/logs/logs.controller.ts
 import { Controller, Get, Res, Req, Param, UseGuards } from '@nestjs/common';
 import { Request, Response } from 'express';
 import { LogsService } from './logs.service';
 import { SessionGuard } from '../session.guard';
+import { KEEP_ALIVE_MESSAGE, SSE_HEADER } from '../../../src/constants/sse';
 
 @Controller('logs')
 @UseGuards(SessionGuard)
@@ -24,6 +24,25 @@ export class LogsController {
   @Get('metrics')
   getLogMetrics() {
     return this.logsService.readLogMetrics();
+  }
+
+  @Get('priority-log-stream')
+  sse(@Req() req: Request, @Res() res: Response) {
+    res.writeHead(200, SSE_HEADER);
+
+    res.flushHeaders();
+
+    this.logsService.addClient(res);
+
+    const heartbeatInterval = setInterval(() => {
+      res.write(KEEP_ALIVE_MESSAGE);
+    }, 10000);
+
+    req.on('close', () => {
+      clearInterval(heartbeatInterval);
+      this.logsService.removeClient(res);
+      res.end();
+    });
   }
 
   @Get('dismiss/:index')

--- a/backend/src/logs/logs.controller.ts
+++ b/backend/src/logs/logs.controller.ts
@@ -1,8 +1,9 @@
-import { Controller, Get, Res, Req, Param, UseGuards } from '@nestjs/common';
+import {Controller, Get, Res, Req, Param, UseGuards, Query} from '@nestjs/common';
 import { Request, Response } from 'express';
 import { LogsService } from './logs.service';
 import { SessionGuard } from '../session.guard';
 import { KEEP_ALIVE_MESSAGE, SSE_HEADER } from '../../../src/constants/sse';
+import {LogType} from "../../../src/types";
 
 @Controller('logs')
 @UseGuards(SessionGuard)
@@ -24,6 +25,21 @@ export class LogsController {
   @Get('metrics')
   getLogMetrics() {
     return this.logsService.readLogMetrics();
+  }
+
+  @Get('priority-logs')
+  getPriorityLogs(
+    @Query('type') type?: LogType,
+    @Query('limit') limit?: string,
+    @Query('order') order?: string,
+    @Query('since') since?: string,
+  ) {
+    return this.logsService.paginatedPriorityLogs(type, order, since, limit)
+  }
+
+  @Get('log-metrics')
+  getMetrics() {
+    return this.logsService.readMetrics();
   }
 
   @Get('priority-log-stream')

--- a/backend/src/logs/logs.service.ts
+++ b/backend/src/logs/logs.service.ts
@@ -59,7 +59,9 @@ export class LogsService {
           { ignoreDuplicates: true },
         )) as any;
 
-        this.sendMessageToClients(result.dataValues);
+        if(level === LogLevels.ERRO || level === LogLevels.CRIT) {
+          this.sendMessageToClients(result.dataValues);
+        }
 
         if (this.isDebug) {
           console.log(
@@ -133,6 +135,97 @@ export class LogsService {
       errorLogs,
       criticalLogs,
     };
+  }
+
+  async readMetrics(type?: LogType) {
+    if (type && !this.logTypes.includes(type)) {
+      throw new Error('Invalid log type');
+    }
+
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+
+    const warnOptions: any = {
+      where: {
+        level: LogLevels.WARN,
+        createdAt: {
+          [Op.gte]: oneHourAgo,
+        },
+      },
+    };
+    const errorOptions: any = {
+      where: {
+        level: LogLevels.ERRO,
+        createdAt: {
+          [Op.gte]: oneHourAgo,
+        },
+      },
+    };
+    const critOptions: any = {
+      where: {
+        level: LogLevels.CRIT,
+        createdAt: {
+          [Op.gte]: oneHourAgo,
+        },
+      },
+    };
+
+    if (type) {
+      warnOptions.where.type = { [Op.eq]: type };
+      errorOptions.where.type = { [Op.eq]: type };
+      critOptions.where.type = { [Op.eq]: type };
+    }
+
+    const [warningCount, errorCount, criticalCount] = await Promise.all([
+      this.logRepository.count(warnOptions),
+      this.logRepository.count(errorOptions),
+      this.logRepository.count(critOptions),
+    ]);
+
+    return {
+      warningCount,
+      errorCount,
+      criticalCount,
+    };
+
+
+  }
+
+  public async paginatedPriorityLogs(
+    type?: LogType,
+    order?: string | undefined,
+    since?: string | undefined,
+    limit?: string | undefined,
+  ) {
+    let orderQuery = order?.toUpperCase();
+    const queryLimit = limit ? Number(limit) : 16;
+
+    if (orderQuery !== 'ASC' && orderQuery !== 'DESC') {
+      orderQuery = 'DESC';
+    }
+
+    // Build a single where object
+    const whereClause: any = {};
+
+    // If we have a 'since' timestamp, fetch only items older than that
+    if (since) {
+      whereClause.createdAt = {
+        [Op.lt]: new Date(since),
+      };
+    }
+
+    // If 'type' is provided, match that type
+    if (type) {
+      whereClause.type = type;
+    }
+
+    whereClause.level = { [Op.in]: [LogLevels.CRIT, LogLevels.ERRO] };
+    whereClause.isHidden = false
+
+    return this.logRepository.findAll({
+      limit: queryLimit === 0 ? undefined : queryLimit,
+      where: whereClause,
+      order: [['createdAt', orderQuery]],
+    });
   }
 
   async dismissLog(id: string) {

--- a/backend/src/logs/logs.service.ts
+++ b/backend/src/logs/logs.service.ts
@@ -6,6 +6,7 @@ import { LogLevels, LogType, SSELog } from '../../../src/types';
 import { InjectModel } from '@nestjs/sequelize';
 import { Log } from './entities/log.entity';
 import { Op } from 'sequelize';
+import { ClientManager } from '../utils/client-manager';
 
 @Injectable()
 export class LogsService {
@@ -20,6 +21,20 @@ export class LogsService {
 
   private sseStreams: Map<string, Subject<any>> = new Map();
 
+  private clientManager = new ClientManager();
+
+  public addClient(client: Response) {
+    this.clientManager.addClient(client);
+  }
+
+  public removeClient(client: Response) {
+    this.clientManager.removeClient(client);
+  }
+
+  public sendMessageToClients(data: any) {
+    this.clientManager.sendMessageToClients(data);
+  }
+
   public async startSse(url: string, type: LogType) {
     console.log(`starting sse ${url}, ${type}...`);
     const eventSource = new EventSource(url);
@@ -27,7 +42,7 @@ export class LogsService {
     const sseStream: Subject<any> = new Subject();
     this.sseStreams.set(url, sseStream);
 
-    eventSource.onmessage = (event) => {
+    eventSource.onmessage = async (event) => {
       let newData;
 
       try {
@@ -39,10 +54,13 @@ export class LogsService {
       const { level } = newData;
 
       if (level !== LogLevels.INFO) {
-        this.logRepository.create(
+        const result = (await this.logRepository.create(
           { type, level, data: JSON.stringify(newData), isHidden: false },
           { ignoreDuplicates: true },
-        );
+        )) as any;
+
+        this.sendMessageToClients(result.dataValues);
+
         if (this.isDebug) {
           console.log(
             newData,

--- a/backend/src/tasks/tasks.service.ts
+++ b/backend/src/tasks/tasks.service.ts
@@ -60,6 +60,10 @@ export class TasksService implements OnApplicationBootstrap {
         throw new CustomError('No api token found...', 'NO_API_TOKEN');
       }
 
+      await this.logRepository.destroy({
+        truncate: true
+      });
+
       await this.syncBeaconSpecs();
       await this.initValidatorDataScheduler();
       await this.initMetricDataScheduler();

--- a/backend/src/utils/client-manager.ts
+++ b/backend/src/utils/client-manager.ts
@@ -1,0 +1,18 @@
+import { Response } from 'express';
+
+export class ClientManager {
+  private clients: Response[] = [];
+
+  public addClient(client: Response): void {
+    this.clients.push(client);
+  }
+
+  public removeClient(client: Response): void {
+    this.clients = this.clients.filter((c) => c !== client);
+  }
+
+  public sendMessageToClients(data: any): void {
+    const message = `data: ${JSON.stringify(data)}\n\n`;
+    this.clients.forEach((client) => client.write(message));
+  }
+}

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -1068,6 +1068,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
 
+"@types/eventsource@^1.1.15":
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/@types/eventsource/-/eventsource-1.1.15.tgz#949383d3482e20557cbecbf3b038368d94b6be27"
+  integrity sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA==
+
 "@types/express-serve-static-core@^4.17.33":
   version "4.19.0"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.19.0.tgz#3ae8ab3767d98d0b682cda063c3339e1e86ccfaa"
@@ -6049,6 +6054,7 @@ wkx@^0.5.0:
     "@types/node" "*"
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@types/jest": "^29.5.12",
     "@types/js-cookie": "^3.0.6",
     "@types/jsonwebtoken": "^9.0.6",
-    "@types/react": "18.3.12",
+    "@types/react": "19.0.2",
     "@uiw/react-textarea-code-editor": "^2.1.1",
     "autoprefixer": "^10.4.19",
     "axios": "^0.27.2",
@@ -85,7 +85,7 @@
     ]
   },
   "devDependencies": {
-    "@types/node": "22.10.1",
+    "@types/node": "22.10.2",
     "@typescript-eslint/eslint-plugin": "^7.1.0",
     "eslint": "8.57.0",
     "eslint-config-next": "^15.0.3",

--- a/siren.js
+++ b/siren.js
@@ -62,6 +62,9 @@ const handleSSe = (res, req, url) => {
 app.prepare().then(() => {
   const server = express()
   server.get('/activity-stream', (req, res) => handleSSe(res, req, `${backendUrl}/activity/stream`))
+  server.get('/priority-log-stream', (req, res) =>
+    handleSSe(res, req, `${backendUrl}/logs/priority-log-stream`),
+  )
   server.get('/validator-logs', (req, res) => handleSSe(res, req, `${backendUrl}/logs/validator`))
   server.get('/beacon-logs', (req, res) => handleSSe(res, req, `${backendUrl}/logs/beacon`))
 

--- a/src/components/AlertInfo/AlertInfo.tsx
+++ b/src/components/AlertInfo/AlertInfo.tsx
@@ -5,6 +5,7 @@ import sortAlertMessagesBySeverity from '../../../utilities/sortAlerts'
 import useDiagnosticAlerts from '../../hooks/useDiagnosticAlerts'
 import useDivDimensions from '../../hooks/useDivDimensions'
 import useMediaQuery from '../../hooks/useMediaQuery'
+import useSSEData from '../../hooks/useSSEData'
 import { proposerDuties } from '../../recoil/atoms'
 import { LogLevels, StatusColor } from '../../types'
 import AlertCard from '../AlertCard/AlertCard'
@@ -23,6 +24,14 @@ const AlertInfo: FC<AlertInfoProps> = ({ metrics, ...props }) => {
   const headerDimensions = useDivDimensions()
   const [filter, setFilter] = useState('all')
   const duties = useRecoilValue(proposerDuties)
+
+  const { data: streamedData } = useSSEData({
+    url: '/priority-log-stream',
+    isReady: true,
+    isStateStore: true,
+  })
+
+  console.log(streamedData)
 
   const priorityLogAlerts = useMemo(() => {
     return Object.values(metrics)

--- a/src/components/AlertInfo/AlertInfo.tsx
+++ b/src/components/AlertInfo/AlertInfo.tsx
@@ -5,40 +5,25 @@ import sortAlertMessagesBySeverity from '../../../utilities/sortAlerts'
 import useDiagnosticAlerts from '../../hooks/useDiagnosticAlerts'
 import useDivDimensions from '../../hooks/useDivDimensions'
 import useMediaQuery from '../../hooks/useMediaQuery'
-import useSSEData from '../../hooks/useSSEData'
 import { proposerDuties } from '../../recoil/atoms'
-import { LogLevels, StatusColor } from '../../types'
+import {LogData, StatusColor} from '../../types'
 import AlertCard from '../AlertCard/AlertCard'
 import AlertFilterSettings, { FilterValue } from '../AlertFilterSettings/AlertFilterSettings'
-import { LogsInfoProps } from '../DiagnosticTable/LogsInfo'
 import ProposerAlerts, { ProposerAlertsProps } from '../ProposerAlerts/ProposerAlerts'
 import Typography from '../Typography/Typography'
-import PriorityLogAlerts from './PriorityLogAlerts'
+import PriorityLogAlerts from "./PriorityLogAlerts";
 
-export interface AlertInfoProps extends Omit<ProposerAlertsProps, 'duties'>, LogsInfoProps {}
+export interface AlertInfoProps extends Omit<ProposerAlertsProps, 'duties'> {
+  priorityLogs: LogData[]
+}
 
-const AlertInfo: FC<AlertInfoProps> = ({ metrics, ...props }) => {
+const AlertInfo: FC<AlertInfoProps> = ({ priorityLogs, ...props }) => {
   const { t } = useTranslation()
   const { alerts, dismissAlert, resetDismissed } = useDiagnosticAlerts()
   const { ref, dimensions } = useDivDimensions()
   const headerDimensions = useDivDimensions()
   const [filter, setFilter] = useState('all')
   const duties = useRecoilValue(proposerDuties)
-
-  const { data: streamedData } = useSSEData({
-    url: '/priority-log-stream',
-    isReady: true,
-    isStateStore: true,
-  })
-
-  console.log(streamedData)
-
-  const priorityLogAlerts = useMemo(() => {
-    return Object.values(metrics)
-      .flat()
-      .filter(({ level }) => level === LogLevels.CRIT || level === LogLevels.ERRO)
-      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-  }, [metrics])
 
   const setFilterValue = (value: FilterValue) => setFilter(value)
   const isMobile = useMediaQuery('(max-width: 425px)')
@@ -56,8 +41,8 @@ const AlertInfo: FC<AlertInfoProps> = ({ metrics, ...props }) => {
   const isSeverFilter = filter === 'all' || filter === StatusColor.ERROR
 
   const isFiller =
-    formattedAlerts.length + (duties?.length || 0) + (priorityLogAlerts.length || 0) < 6
-  const isPriorityAlerts = priorityLogAlerts.length > 0
+    formattedAlerts.length + (duties?.length || 0) + (priorityLogs.length || 0) < 6
+  const isPriorityAlerts = priorityLogs.length > 0
   const isAlerts = formattedAlerts.length > 0 || duties?.length > 0 || isPriorityAlerts
   const isProposerAlerts =
     duties?.length > 0 && (filter === 'all' || filter === StatusColor.SUCCESS)
@@ -95,7 +80,7 @@ const AlertInfo: FC<AlertInfoProps> = ({ metrics, ...props }) => {
           {isAlerts && (
             <div className={`overflow-scroll scrollbar-hide ${!isFiller ? 'flex-1' : ''}`}>
               {isPriorityAlerts && isSeverFilter && (
-                <PriorityLogAlerts alerts={priorityLogAlerts} />
+                <PriorityLogAlerts alerts={priorityLogs} />
               )}
               {formattedAlerts.map((alert) => {
                 const { severity, subText, message, id } = alert

--- a/src/components/AlertInfo/PriorityLogAlerts.tsx
+++ b/src/components/AlertInfo/PriorityLogAlerts.tsx
@@ -3,8 +3,11 @@ import moment from 'moment'
 import { FC, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import displayToast from '../../../utilities/displayToast'
+import {FETCH_LOG_LIMIT} from "../../constants/constants";
+import useSSEData from "../../hooks/useSSEData";
 import { LogData, StatusColor, ToastType } from '../../types'
 import AlertCard from '../AlertCard/AlertCard'
+import Typography from "../Typography/Typography";
 
 export interface LogAlertsProps {
   alerts: LogData[]
@@ -12,15 +15,33 @@ export interface LogAlertsProps {
 
 const PriorityLogAlerts: FC<LogAlertsProps> = ({ alerts }) => {
   const { t } = useTranslation()
+  const [data, setData] = useState<LogData[]>(alerts)
+  const [hasMoreLogs, setHasMoreLogs] = useState(false)
 
-  const [data, setData] = useState(alerts)
+  const { data: streamedData } = useSSEData({
+    url: '/priority-log-stream',
+    isReady: true,
+    isStateStore: true,
+  })
 
   useEffect(() => {
-    setData(alerts)
+    if(streamedData.length) {
+      setData((prev) => {
+        const combined = [...prev, ...streamedData];
+        return [...new Map(combined.map(item => [item.id, item])).values()];
+      });
+    }
+  }, [streamedData])
+
+  useEffect(() => {
+    if(alerts.length >= FETCH_LOG_LIMIT) {
+      setHasMoreLogs(true)
+    }
   }, [alerts])
 
-  const visibleAlerts = useMemo(() => {
+  const visibleOrderedAlerts = useMemo(() => {
     return data.filter(({ isHidden }) => !isHidden)
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
   }, [data])
 
   const dismissAlert = async (id: number) => {
@@ -47,20 +68,55 @@ const PriorityLogAlerts: FC<LogAlertsProps> = ({ alerts }) => {
     }
   }
 
-  return visibleAlerts.map(({ id, data, createdAt }) => {
-    const alertData = JSON.parse(data)
-    const date = moment(createdAt).fromNow()
-    return (
-      <AlertCard
-        key={id}
-        status={StatusColor.ERROR}
-        count={3}
-        onClick={() => dismissAlert(id)}
-        subText={t('poor')}
-        text={`${alertData.msg} ${date}`}
-      />
-    )
-  })
+  const fetchOlderLogs = async () => {
+    try {
+      const oldestLogDate = data.reduce((oldest, current) => {
+        return new Date(current.createdAt) < new Date(oldest.createdAt) ? current : oldest;
+      }).createdAt
+
+      const { data: fetchedData } = await axios.get(`/api/priority-logs?since=${oldestLogDate}`)
+
+      if(fetchedData.length) {
+        if(fetchedData.length < FETCH_LOG_LIMIT) {
+          setHasMoreLogs(false)
+        }
+        setData((prev) => {
+          const combined = [...prev, ...fetchedData];
+          return [...new Map(combined.map(item => [item.id, item])).values()];
+        });
+      }
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  return (
+    <>
+      {
+        visibleOrderedAlerts.map(({ id, data, createdAt }) => {
+          const alertData = JSON.parse(data)
+          const date = moment(createdAt).fromNow()
+          return (
+            <AlertCard
+              key={id}
+              status={StatusColor.ERROR}
+              count={3}
+              onClick={() => dismissAlert(id)}
+              subText={t('poor')}
+              text={`${alertData.msg} ${date}`}
+            />
+          )
+        })
+      }
+      {
+        hasMoreLogs ? (
+          <div onClick={fetchOlderLogs} className="w-full bg-red-600 p-2">
+            <Typography>Load More Logs</Typography>
+          </div>
+        ) : null
+      }
+    </>
+  )
 }
 
 export default PriorityLogAlerts

--- a/src/components/AlertInfo/PriorityLogAlerts.tsx
+++ b/src/components/AlertInfo/PriorityLogAlerts.tsx
@@ -1,13 +1,14 @@
 import axios from 'axios'
 import moment from 'moment'
-import { FC, useEffect, useMemo, useState } from 'react'
+import { FC, useEffect, useMemo, useState, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import displayToast from '../../../utilities/displayToast'
-import {FETCH_LOG_LIMIT} from "../../constants/constants";
-import useSSEData from "../../hooks/useSSEData";
+import { FETCH_LOG_LIMIT } from '../../constants/constants'
+import useSSEData from '../../hooks/useSSEData'
 import { LogData, StatusColor, ToastType } from '../../types'
 import AlertCard from '../AlertCard/AlertCard'
-import Typography from "../Typography/Typography";
+import Spinner from '../Spinner/Spinner'
+import Typography from '../Typography/Typography'
 
 export interface LogAlertsProps {
   alerts: LogData[]
@@ -16,7 +17,8 @@ export interface LogAlertsProps {
 const PriorityLogAlerts: FC<LogAlertsProps> = ({ alerts }) => {
   const { t } = useTranslation()
   const [data, setData] = useState<LogData[]>(alerts)
-  const [hasMoreLogs, setHasMoreLogs] = useState(false)
+  const [hasMoreLogs, setHasMoreLogs] = useState(alerts.length >= FETCH_LOG_LIMIT)
+  const [isLoading, setIsLoading] = useState(false)
 
   const { data: streamedData } = useSSEData({
     url: '/priority-log-stream',
@@ -25,96 +27,101 @@ const PriorityLogAlerts: FC<LogAlertsProps> = ({ alerts }) => {
   })
 
   useEffect(() => {
-    if(streamedData.length) {
-      setData((prev) => {
-        const combined = [...prev, ...streamedData];
-        return [...new Map(combined.map(item => [item.id, item])).values()];
-      });
-    }
+    if(!streamedData?.length) return
+
+    setData((prev) => {
+      const combined = [...prev, ...streamedData]
+      return Array.from(new Map(combined.map((item) => [item.id, item])).values())
+    })
   }, [streamedData])
 
   useEffect(() => {
-    if(alerts.length >= FETCH_LOG_LIMIT) {
+    if (alerts.length >= FETCH_LOG_LIMIT) {
       setHasMoreLogs(true)
     }
   }, [alerts])
 
   const visibleOrderedAlerts = useMemo(() => {
-    return data.filter(({ isHidden }) => !isHidden)
+    return data
+      .filter(({ isHidden }) => !isHidden)
       .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+      .map((alert) => ({
+        ...alert,
+        data: JSON.parse(alert.data),
+        fromNowStamp: moment(alert.createdAt).fromNow(),
+      }))
   }, [data])
 
-  const dismissAlert = async (id: number) => {
+  const dismissAlert = useCallback(async (id: number) => {
     try {
-      const { status } = await axios.put(`/api/dismiss-log/${id}`, undefined)
+      const { status } = await axios.put(`/api/dismiss-log/${id}`)
 
-      if (status === 200) {
-        setData((prev) => {
-          let log = prev.find((alert) => alert.id === id)
+      if(status !== 200) return
 
-          if (!log) {
-            return prev
-          }
-
-          log.isHidden = true
-
-          return [...prev.filter((alert) => alert.id !== id), log] as LogData[]
-        })
-        displayToast(t('alertMessages.dismiss.success'), ToastType.SUCCESS)
-      }
-    } catch (e) {
-      console.error('error updating log...')
+      setData((prev) =>
+        prev.map((alert) => (alert.id === id ? { ...alert, isHidden: true } : alert))
+      )
+      displayToast(t('alertMessages.dismiss.success'), ToastType.SUCCESS)
+    } catch (error) {
+      console.error('Error updating log:', error)
       displayToast(t('alertMessages.dismiss.error'), ToastType.ERROR)
     }
-  }
+  }, [t])
 
-  const fetchOlderLogs = async () => {
+  const fetchOlderLogs = useCallback(async () => {
+    setIsLoading(true)
     try {
-      const oldestLogDate = data.reduce((oldest, current) => {
-        return new Date(current.createdAt) < new Date(oldest.createdAt) ? current : oldest;
-      }).createdAt
+      const oldestLog = data.reduce((oldest, current) =>
+        new Date(current.createdAt) < new Date(oldest.createdAt) ? current : oldest
+      )
+      const oldestLogDate = oldestLog.createdAt
 
       const { data: fetchedData } = await axios.get(`/api/priority-logs?since=${oldestLogDate}`)
 
-      if(fetchedData.length) {
-        if(fetchedData.length < FETCH_LOG_LIMIT) {
-          setHasMoreLogs(false)
-        }
-        setData((prev) => {
-          const combined = [...prev, ...fetchedData];
-          return [...new Map(combined.map(item => [item.id, item])).values()];
-        });
+      const count = fetchedData?.length
+
+      if(!count) return
+
+      if (count < FETCH_LOG_LIMIT) {
+        setHasMoreLogs(false)
       }
-    } catch (e) {
-      console.error(e)
+      setData((prev) => {
+        const combined = [...prev, ...fetchedData]
+        return Array.from(new Map(combined.map((item) => [item.id, item])).values())
+      })
+    } catch (error) {
+      console.error('Error fetching older logs:', error)
+    } finally {
+      setIsLoading(false)
     }
-  }
+  }, [data])
 
   return (
     <>
-      {
-        visibleOrderedAlerts.map(({ id, data, createdAt }) => {
-          const alertData = JSON.parse(data)
-          const date = moment(createdAt).fromNow()
-          return (
-            <AlertCard
-              key={id}
-              status={StatusColor.ERROR}
-              count={3}
-              onClick={() => dismissAlert(id)}
-              subText={t('poor')}
-              text={`${alertData.msg} ${date}`}
-            />
-          )
-        })
-      }
-      {
-        hasMoreLogs ? (
-          <div onClick={fetchOlderLogs} className="w-full bg-red-600 p-2">
-            <Typography>Load More Logs</Typography>
-          </div>
-        ) : null
-      }
+      {visibleOrderedAlerts.map(({ id, data: alertData, fromNowStamp }) => (
+        <AlertCard
+          key={id}
+          status={StatusColor.ERROR}
+          count={3}
+          onClick={() => dismissAlert(id)}
+          subText={t('poor')}
+          text={`${alertData.msg} ${fromNowStamp}`}
+        />
+      ))}
+      {hasMoreLogs && (
+        <div
+          onClick={fetchOlderLogs}
+          className="w-full flex items-center justify-center cursor-pointer bg-dark800 hover:bg-dark750 border-b-style500 p-2"
+        >
+          {isLoading ? (
+            <Spinner size="w-4 h-4" />
+          ) : (
+            <Typography className="center" type="text-caption2">
+              {t('fetchMoreLogAlerts')}
+            </Typography>
+          )}
+        </div>
+      )}
     </>
   )
 }

--- a/src/components/DiagnosticTable/DiagnosticTable.tsx
+++ b/src/components/DiagnosticTable/DiagnosticTable.tsx
@@ -5,12 +5,12 @@ import LogsInfo, { LogsInfoProps } from './LogsInfo'
 
 export interface DiagnosticTableProps extends HardwareInfoProps, AlertInfoProps, LogsInfoProps {}
 
-const DiagnosticTable: FC<DiagnosticTableProps> = ({ syncData, beanHealth, metrics, bnSpec }) => {
+const DiagnosticTable: FC<DiagnosticTableProps> = ({ syncData, beanHealth, logMetrics, bnSpec, priorityLogs }) => {
   return (
     <div className='flex-1 flex flex-col space-y-4 md:space-y-0 md:flex-row mt-2 w-full'>
       <HardwareInfo syncData={syncData} beanHealth={beanHealth} />
-      <LogsInfo metrics={metrics} />
-      <AlertInfo bnSpec={bnSpec} metrics={metrics} syncData={syncData} />
+      <LogsInfo logMetrics={logMetrics} />
+      <AlertInfo bnSpec={bnSpec} priorityLogs={priorityLogs} syncData={syncData} />
     </div>
   )
 }

--- a/src/components/DiagnosticTable/LogsInfo.tsx
+++ b/src/components/DiagnosticTable/LogsInfo.tsx
@@ -2,15 +2,15 @@ import Link from 'next/link'
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import useMediaQuery from '../../hooks/useMediaQuery'
-import { LogMetric } from '../../types'
+import { Metric} from '../../types'
 import LogStats from '../LogStats/LogStats'
 import Typography from '../Typography/Typography'
 
 export interface LogsInfoProps {
-  metrics: LogMetric
+  logMetrics: Metric
 }
 
-const LogsInfo: FC<LogsInfoProps> = ({ metrics }) => {
+const LogsInfo: FC<LogsInfoProps> = ({ logMetrics }) => {
   const { t } = useTranslation()
   const isMobile = useMediaQuery('(max-width: 425px)')
   const size = isMobile ? 'health' : 'md'
@@ -38,7 +38,7 @@ const LogsInfo: FC<LogsInfoProps> = ({ metrics }) => {
         errorToolTip={t('logs.tooltips.combinedError')}
         warnToolTip={t('logs.tooltips.combinedWarning')}
         size={size}
-        metrics={metrics}
+        logMetrics={logMetrics}
       />
     </div>
   )

--- a/src/components/LogStats/LogStats.tsx
+++ b/src/components/LogStats/LogStats.tsx
@@ -1,59 +1,42 @@
-import { FC, useMemo } from 'react'
+import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import timeFilterObjArray from '../../../utilities/timeFilterObjArray'
 import toFixedIfNecessary from '../../../utilities/toFixedIfNecessary'
-import { LogMetric, StatusColor } from '../../types'
+import { Metric, StatusColor} from '../../types'
 import DiagnosticCard, { CardSize } from '../DiagnosticCard/DiagnosticCard'
 
 export interface LogStatsProps {
   critToolTip?: string
   warnToolTip?: string
   errorToolTip?: string
-  metrics: LogMetric
+  logMetrics: Metric
   size?: CardSize
   maxHeight?: string
   maxWidth?: string
 }
 
 const LogStats: FC<LogStatsProps> = ({
-  metrics,
   size,
   maxHeight = 'flex-1',
   maxWidth,
   critToolTip,
   warnToolTip,
   errorToolTip,
+  logMetrics
 }) => {
   const { t } = useTranslation()
-  const { criticalLogs, warningLogs, errorLogs } = metrics
+  const { errorCount, criticalCount, warningCount } = logMetrics
 
-  const hourlyCriticalLogs = useMemo(() => {
-    return timeFilterObjArray(criticalLogs, 'createdAt', 'minutes', 60)
-  }, [criticalLogs])
-
-  const hourlyWarningLogs = useMemo(() => {
-    return timeFilterObjArray(warningLogs, 'createdAt', 'minutes', 60)
-  }, [warningLogs])
-
-  const hourlyErrorLogs = useMemo(() => {
-    return timeFilterObjArray(errorLogs, 'createdAt', 'minutes', 60)
-  }, [errorLogs])
-
-  const criticalMetrics = hourlyCriticalLogs.length
-  const warningMetrics = hourlyWarningLogs.length
-  const errorMetrics = hourlyErrorLogs.length
-
-  const critStatus = criticalMetrics > 0 ? StatusColor.ERROR : StatusColor.SUCCESS
+  const critStatus = criticalCount > 0 ? StatusColor.ERROR : StatusColor.SUCCESS
   const errorStatus =
-    errorMetrics <= 0
+    errorCount <= 0
       ? StatusColor.SUCCESS
-      : errorMetrics <= 2
+      : errorCount <= 2
         ? StatusColor.WARNING
         : StatusColor.ERROR
   const warnStatus =
-    warningMetrics < 5
+    warningCount < 5
       ? StatusColor.SUCCESS
-      : warningMetrics <= 50
+      : warningCount <= 50
         ? StatusColor.WARNING
         : StatusColor.ERROR
 
@@ -68,7 +51,7 @@ const LogStats: FC<LogStatsProps> = ({
         size={size}
         border='border-t-0 md:border-l-0 border-style500'
         subTitle={t('critical')}
-        metric={`${toFixedIfNecessary(criticalMetrics, 2)} / HR`}
+        metric={`${toFixedIfNecessary(criticalCount, 2)} / HR`}
       />
       <DiagnosticCard
         isBackground={false}
@@ -80,7 +63,7 @@ const LogStats: FC<LogStatsProps> = ({
         size={size}
         border='border-t-0 md:border-l-0 border-style500'
         subTitle={t('logInfo.validatorLogs')}
-        metric={`${toFixedIfNecessary(errorMetrics, 2)} / HR`}
+        metric={`${toFixedIfNecessary(errorCount, 2)} / HR`}
       />
       <DiagnosticCard
         isBackground={false}
@@ -92,7 +75,7 @@ const LogStats: FC<LogStatsProps> = ({
         size={size}
         border='border-t-0 md:border-l-0 border-style500'
         subTitle={t('logInfo.validatorLogs')}
-        metric={`${toFixedIfNecessary(warningMetrics, 2)} / HR`}
+        metric={`${toFixedIfNecessary(warningCount, 2)} / HR`}
       />
     </>
   )

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -162,4 +162,5 @@ export const ALERT_ID = {
 
 export const DEVICE_NAME_TRUNCATE = 10
 export const EFFECTIVE_BALANCE = 32
+export const FETCH_LOG_LIMIT = 15
 export const CONSOLIDATION_CONTRACT = '0x01aBEa29659e5e97C95107F20bb753cD3e09bBBb'

--- a/src/constants/sse.ts
+++ b/src/constants/sse.ts
@@ -1,0 +1,8 @@
+export const SSE_HEADER = {
+  'Content-Type': 'text/event-stream',
+  'Cache-Control': 'no-cache',
+  Connection: 'keep-alive',
+  'X-Accel-Buffering': 'no',
+}
+
+export const KEEP_ALIVE_MESSAGE = ': keep-alive\n\n'

--- a/src/locales/translations/en-US.json
+++ b/src/locales/translations/en-US.json
@@ -74,6 +74,7 @@
   "viewDisclosures": "view important disclosures",
   "learnMore": "Learn More",
   "tooManyValidatorWarning": "It is not recommended to add this many validators at once. You can more when finished with the ones below.",
+  "fetchMoreLogAlerts": "Load Older Log Alerts",
   "disclosure": {
     "healthCheck": {
       "title": "Health Check Disclosure",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -50,6 +50,12 @@ export type LogMetric = {
   criticalLogs: LogData[]
 }
 
+export type Metric = {
+  warningCount: number
+  errorCount: number
+  criticalCount: number
+}
+
 export enum LogType {
   VALIDATOR = 'VALIDATOR',
   BEACON = 'BEACON',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2605,10 +2605,17 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.34.tgz#10964ba0dee6ac4cd462e2795b6bebd407303433"
   integrity sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==
 
-"@types/node@*", "@types/node@22.10.1":
+"@types/node@*":
   version "22.10.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.10.1.tgz#41ffeee127b8975a05f8c4f83fb89bcb2987d766"
   integrity sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==
+  dependencies:
+    undici-types "~6.20.0"
+
+"@types/node@22.10.2":
+  version "22.10.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.10.2.tgz#a485426e6d1fdafc7b0d4c7b24e2c78182ddabb9"
+  integrity sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==
   dependencies:
     undici-types "~6.20.0"
 
@@ -2641,12 +2648,19 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@18.3.12":
+"@types/react@*":
   version "18.3.12"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.12.tgz#99419f182ccd69151813b7ee24b792fe08774f60"
   integrity sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==
   dependencies:
     "@types/prop-types" "*"
+    csstype "^3.0.2"
+
+"@types/react@19.0.2":
+  version "19.0.2"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.0.2.tgz#9363e6b3ef898c471cb182dd269decc4afc1b4f6"
+  integrity sha512-USU8ZI/xyKJwFTpjSVIrSeHBVAGagkHQKPNbxeWwql/vDmnTIBgx+TJnhFnj1NXgz8XfprU0egV2dROLGpsBEg==
+  dependencies:
     csstype "^3.0.2"
 
 "@types/stack-utils@^2.0.0":


### PR DESCRIPTION
It is possible to have high amount of ERRO and CRIT logs while nodes are running. This can cause Siren to store a large amount of logs and slow down the api request, subsequently making the ssr first build slower when navigating to the main dashboard.

This pr resolves that by creating a pagination effect for the priority logs displayed in the alerts component. By default Siren will fetch the most recent 15 logs and will allow the user to request older logs via button press. this prevents the first request from dumping 100s of logs and slowing down siren

https://github.com/sigp/siren/issues/251