### PR TITLE
Feat/end session

### DIFF
--- a/app/api/logout/route.ts
+++ b/app/api/logout/route.ts
@@ -11,12 +11,17 @@ export async function POST(req: Request) {
       method: 'POST'
     })
 
-    return NextResponse.json(true, { status })
+    const response = NextResponse.json(true, { status })
+
+    response.cookies.delete('session-token')
+
+    return response
+
   } catch (error: any) {
     let message = error?.response?.data?.message
 
     if (!message) {
-      message = 'authPrompt.defaultErrorMessage'
+      message = 'authPrompt.unableToEndSession'
     }
 
     console.log(error)

--- a/app/api/logout/route.ts
+++ b/app/api/logout/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server'
+import fetchFromApi from "../../../utilities/fetchFromApi";
+import getReqAuthToken from "../../../utilities/getReqAuthToken";
+
+const backendUrl = process.env.BACKEND_URL
+
+export async function POST(req: Request) {
+  try {
+    const token = getReqAuthToken(req)
+    const { status } = await fetchFromApi(`${backendUrl}/logout`, token, {
+      method: 'POST'
+    })
+
+    return NextResponse.json(true, { status })
+  } catch (error: any) {
+    let message = error?.response?.data?.message
+
+    if (!message) {
+      message = 'authPrompt.defaultErrorMessage'
+    }
+
+    console.log(error)
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/dashboard/settings/Main.tsx
+++ b/app/dashboard/settings/Main.tsx
@@ -1,33 +1,31 @@
 'use client'
 
-import React, { FC, useState } from 'react'
-import { useTranslation } from 'react-i18next'
+import axios from "axios";
+import {useRouter} from "next/navigation";
+import React, {FC, useState} from 'react'
+import {useTranslation} from 'react-i18next'
 import LighthouseSvg from '../../../src/assets/images/lighthouse-black.svg'
 import AppDescription from '../../../src/components/AppDescription/AppDescription'
 import AppVersion from '../../../src/components/AppVersion/AppVersion'
+import Button, {ButtonFace} from "../../../src/components/Button/Button";
 import DashboardWrapper from '../../../src/components/DashboardWrapper/DashboardWrapper'
 import Input from '../../../src/components/Input/Input'
 import SocialIcon from '../../../src/components/SocialIcon/SocialIcon'
 import Toggle from '../../../src/components/Toggle/Toggle'
 import Typography from '../../../src/components/Typography/Typography'
 import UiModeIcon from '../../../src/components/UiModeIcon/UiModeIcon'
-import {
-  DiscordUrl,
-  LighthouseBookUrl,
-  SigPGithubUrl,
-  SigPIoUrl,
-  SigPTwitter,
-} from '../../../src/constants/constants'
-import { UiMode } from '../../../src/constants/enums'
+import {DiscordUrl, LighthouseBookUrl, SigPGithubUrl, SigPIoUrl, SigPTwitter,} from '../../../src/constants/constants'
+import {UiMode} from '../../../src/constants/enums'
 import useLocalStorage from '../../../src/hooks/useLocalStorage'
 import useNetworkMonitor from '../../../src/hooks/useNetworkMonitor'
 import useSWRPolling from '../../../src/hooks/useSWRPolling'
 import useUiMode from '../../../src/hooks/useUiMode'
-import { ActivityResponse, OptionalString } from '../../../src/types'
-import { BeaconNodeSpecResults, SyncData } from '../../../src/types/beacon'
-import { Diagnostics } from '../../../src/types/diagnostic'
-import { UsernameStorage } from '../../../src/types/storage'
+import {ActivityResponse, OptionalString, ToastType} from '../../../src/types'
+import {BeaconNodeSpecResults, SyncData} from '../../../src/types/beacon'
+import {Diagnostics} from '../../../src/types/diagnostic'
+import {UsernameStorage} from '../../../src/types/storage'
 import addClassString from '../../../utilities/addClassString'
+import displayToast from "../../../utilities/displayToast";
 
 export interface MainProps {
   initNodeHealth: Diagnostics
@@ -49,7 +47,9 @@ const Main: FC<MainProps> = (props) => {
     initActivityData,
   } = props
 
+  const router = useRouter()
   const { SECONDS_PER_SLOT } = beaconSpec
+  const [isLoading, setIsLoading] = useState(false)
   const { isValidatorError, isBeaconError } = useNetworkMonitor()
   const { mode, toggleUiMode } = useUiMode()
   const [userNameError, setError] = useState<OptionalString>()
@@ -64,6 +64,28 @@ const Main: FC<MainProps> = (props) => {
     }
 
     storeUserName(value)
+  }
+
+  const handleError = () => {
+    displayToast(t('authPrompt.unexpectedErrorLogout'), ToastType.ERROR)
+
+  }
+
+  const logout = async () => {
+    try {
+      setIsLoading(true)
+      const { status } = await axios.post('/api/logout' )
+
+      if(status === 200) {
+        router.push('/')
+        return
+      }
+      handleError()
+    } catch (e) {
+      handleError()
+    } finally {
+      setIsLoading(false)
+    }
   }
 
   const networkError = isValidatorError || isBeaconError
@@ -192,6 +214,9 @@ const Main: FC<MainProps> = (props) => {
                 value={username}
               />
             </div>
+          </div>
+          <div className="pt-8">
+            <Button isLoading={isLoading} onClick={logout} type={ButtonFace.ERROR}>{t('endSession')}</Button>
           </div>
         </div>
       </div>

--- a/app/error/Main.tsx
+++ b/app/error/Main.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import '../../src/i18n'
 import { useTranslation } from 'react-i18next'
 import Button, { ButtonFace } from '../../src/components/Button/Button'
 import Typography from '../../src/components/Typography/Typography'

--- a/backend/src/activity/activity.module.ts
+++ b/backend/src/activity/activity.module.ts
@@ -3,9 +3,10 @@ import { ActivityController } from './activity.controller';
 import { ActivityService } from './activity.service';
 import { SequelizeModule } from '@nestjs/sequelize';
 import { Activity } from './entities/activity.entity';
+import {AuthModule} from "../auth.module";
 
 @Module({
-  imports: [SequelizeModule.forFeature([Activity])],
+  imports: [SequelizeModule.forFeature([Activity]), AuthModule],
   controllers: [ActivityController],
   providers: [ActivityService],
   exports: [ActivityService],

--- a/backend/src/activity/tests/activity.controller.spec.ts
+++ b/backend/src/activity/tests/activity.controller.spec.ts
@@ -8,6 +8,7 @@ import { HttpService } from '@nestjs/axios';
 import { Sequelize } from 'sequelize-typescript';
 import { JwtModule } from '@nestjs/jwt';
 import { ActivityType } from '../../../../src/types';
+import {AuthModule} from "../../auth.module";
 
 describe('ActivityController', () => {
   const baseRowData = {
@@ -58,6 +59,7 @@ describe('ActivityController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [
+        AuthModule,
         SequelizeModule.forFeature([Activity]),
         SequelizeModule.forRoot({
           dialect: 'sqlite',

--- a/backend/src/app.controller.spec.ts
+++ b/backend/src/app.controller.spec.ts
@@ -3,6 +3,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { JwtModule } from '@nestjs/jwt';
 import { UnauthorizedException } from '@nestjs/common';
+import {CacheModule} from "@nestjs/cache-manager";
 
 describe('AppController', () => {
   let appController: AppController;
@@ -11,6 +12,7 @@ describe('AppController', () => {
     jest.resetModules();
     const app: TestingModule = await Test.createTestingModule({
       imports: [
+        CacheModule.register(),
         JwtModule.register({
           global: true,
           secret: 'fake-value',

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,5 +1,6 @@
-import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import {Body, Controller, HttpCode, HttpStatus, Post, UseGuards, Req} from '@nestjs/common';
 import { AppService } from './app.service';
+import {SessionGuard} from "./session.guard";
 
 @Controller()
 export class AppController {
@@ -9,5 +10,16 @@ export class AppController {
   @Post('authenticate')
   authenticate(@Body() data: Record<string, any>) {
     return this.appService.authenticateSessionPassword(data.password);
+  }
+
+  @Post('/logout')
+  @UseGuards(SessionGuard)
+  async logoutSession(@Req() req: Request) {
+    const authHeader = req.headers['authorization'];
+    if (!authHeader) {
+      throw new Error('No Authorization header');
+    }
+    const token = authHeader.split(' ')[1];
+    return await this.appService.invalidateToken(token);
   }
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -13,6 +13,7 @@ import { TasksModule } from './tasks/tasks.module';
 import { JwtModule } from '@nestjs/jwt';
 import { GracefulShutdownModule } from 'nestjs-graceful-shutdown';
 import { ActivityModule } from './activity/activity.module';
+import {CacheModule} from "@nestjs/cache-manager";
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { ActivityModule } from './activity/activity.module';
       secret: process.env.API_TOKEN,
       signOptions: { expiresIn: '7200s' }, //set to  2 hours
     }),
+    CacheModule.register(),
     ScheduleModule.forRoot(),
     LogsModule,
     TasksModule,

--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -1,10 +1,44 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import {Inject, Injectable, UnauthorizedException} from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
+import {CACHE_MANAGER} from "@nestjs/cache-manager";
+import {Cache} from "cache-manager";
+import { v4 as uuidV4 } from 'uuid'
 
 @Injectable()
 export class AppService {
-  constructor(private jwtService: JwtService) {}
+  constructor(
+    private jwtService: JwtService,
+    @Inject(CACHE_MANAGER)
+    private cacheManager: Cache
+  ) {}
   private sessionPassword = process.env.SESSION_PASSWORD;
+
+  async invalidateToken(token: string) {
+    const decoded = this.jwtService.decode(token) as any;
+    if (!decoded || !decoded.exp || !decoded.jti) {
+      throw new UnauthorizedException('Invalid token');
+    }
+
+    const expiresIn = decoded.exp * 1000 - Date.now();
+
+    if (expiresIn <= 0) {
+      return { message: 'Token is already expired' };
+    }
+
+    await this.cacheManager.set(`blacklist:${decoded.jti}`, 'blacklisted', expiresIn);
+
+    return { message: 'Token invalidated' };
+  }
+
+  async isTokenBlacklisted(token: string): Promise<boolean> {
+    const decoded = this.jwtService.decode(token) as any;
+    if (!decoded || !decoded.jti) {
+      return false;
+    }
+
+    const result = await this.cacheManager.get(`blacklist:${decoded.jti}`);
+    return result === 'blacklisted';
+  }
 
   async authenticateSessionPassword(password: string) {
     if (!this.sessionPassword) {
@@ -15,7 +49,8 @@ export class AppService {
       throw new UnauthorizedException('authPrompt.invalidPassword');
     }
 
-    const payload = { sub: 'authenticated_session' };
+    const jti = uuidV4().toString();
+    const payload = { sub: 'authenticated_session', jti };
 
     return {
       access_token: await this.jwtService.signAsync(payload),

--- a/backend/src/auth.module.ts
+++ b/backend/src/auth.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { AppService } from './app.service';
+import { JwtModule } from '@nestjs/jwt';
+import { CacheModule } from '@nestjs/cache-manager';
+
+@Module({
+  imports: [
+    JwtModule.register({
+      secret: process.env.API_TOKEN,
+      signOptions: { expiresIn: '7200s' },
+    }),
+    CacheModule.register(),
+  ],
+  providers: [AppService],
+  exports: [AppService],
+})
+export class AuthModule {}

--- a/backend/src/beacon/beacon.module.ts
+++ b/backend/src/beacon/beacon.module.ts
@@ -3,9 +3,10 @@ import { BeaconService } from './beacon.service';
 import { BeaconController } from './beacon.controller';
 import { UtilsModule } from '../utils/utils.module';
 import { CacheModule } from '@nestjs/cache-manager';
+import {AuthModule} from "../auth.module";
 
 @Module({
-  imports: [UtilsModule, CacheModule.register()],
+  imports: [UtilsModule, CacheModule.register(), AuthModule],
   controllers: [BeaconController],
   providers: [BeaconService],
 })

--- a/backend/src/beacon/tests/beacon.controller.spec.ts
+++ b/backend/src/beacon/tests/beacon.controller.spec.ts
@@ -15,6 +15,7 @@ import {
   mockValCacheValues,
 } from '../../../../src/mocks/beacon';
 import { StatusColor } from '../../../../src/types';
+import {AuthModule} from "../../auth.module";
 
 describe('BeaconController', () => {
   let controller: BeaconController;
@@ -33,6 +34,7 @@ describe('BeaconController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [
+        AuthModule,
         UtilsModule,
         CacheModule.register(),
         JwtModule.register({

--- a/backend/src/logs/logs.module.ts
+++ b/backend/src/logs/logs.module.ts
@@ -4,9 +4,10 @@ import { UtilsModule } from '../utils/utils.module';
 import { LogsService } from './logs.service';
 import { SequelizeModule } from '@nestjs/sequelize';
 import { Log } from './entities/log.entity';
+import {AuthModule} from "../auth.module";
 
 @Module({
-  imports: [UtilsModule, SequelizeModule.forFeature([Log])],
+  imports: [UtilsModule, SequelizeModule.forFeature([Log]), AuthModule],
   controllers: [LogsController],
   providers: [LogsService],
   exports: [LogsService],

--- a/backend/src/logs/tests/logs.controller.spec.ts
+++ b/backend/src/logs/tests/logs.controller.spec.ts
@@ -14,6 +14,7 @@ import {
   mockErrorLog,
   mockWarningLog,
 } from '../../../../src/mocks/logs';
+import {AuthModule} from "../../auth.module";
 
 describe('LogsController', () => {
   let logsService: LogsService;
@@ -34,6 +35,7 @@ describe('LogsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [
+        AuthModule,
         UtilsModule,
         SequelizeModule.forFeature([Log]),
         SequelizeModule.forRoot({

--- a/backend/src/node/node.module.ts
+++ b/backend/src/node/node.module.ts
@@ -3,9 +3,10 @@ import { NodeService } from './node.service';
 import { UtilsModule } from '../utils/utils.module';
 import { NodeController } from './node.controller';
 import { CacheModule } from '@nestjs/cache-manager';
+import {AuthModule} from "../auth.module";
 
 @Module({
-  imports: [UtilsModule, CacheModule.register()],
+  imports: [UtilsModule, CacheModule.register(), AuthModule],
   controllers: [NodeController],
   providers: [NodeService],
 })

--- a/backend/src/node/tests/node.controller.spec.ts
+++ b/backend/src/node/tests/node.controller.spec.ts
@@ -9,6 +9,7 @@ import { NodeService } from '../node.service';
 import { AxiosResponse } from 'axios/index';
 import { of } from 'rxjs';
 import { mockDiagnostics } from '../../../../src/mocks/beaconSpec';
+import {AuthModule} from "../../auth.module";
 
 describe('NodeController', () => {
   let controller: NodeController;
@@ -28,6 +29,7 @@ describe('NodeController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [
+        AuthModule,
         UtilsModule,
         CacheModule.register(),
         JwtModule.register({

--- a/backend/src/session.guard.ts
+++ b/backend/src/session.guard.ts
@@ -6,11 +6,15 @@ import {
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { Request } from 'express';
+import {AppService} from "./app.service";
 
 @Injectable()
 export class SessionGuard implements CanActivate {
   private apiToken = process.env.API_TOKEN;
-  constructor(private jwtService: JwtService) {}
+  constructor(
+    private jwtService: JwtService,
+    private appService: AppService
+  ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
@@ -18,6 +22,11 @@ export class SessionGuard implements CanActivate {
     if (!token) {
       throw new UnauthorizedException();
     }
+
+    if (await this.appService.isTokenBlacklisted(token)) {
+      throw new UnauthorizedException('Token has been invalidated');
+    }
+
     try {
       request['user'] = await this.jwtService.verifyAsync(token, {
         secret: this.apiToken,

--- a/backend/src/validator/tests/validator.controller.spec.ts
+++ b/backend/src/validator/tests/validator.controller.spec.ts
@@ -21,6 +21,7 @@ import { SequelizeModule } from '@nestjs/sequelize';
 import { Metric } from '../entities/metric.entity';
 import { Sequelize } from 'sequelize-typescript';
 import { ActivityModule } from '../../activity/activity.module';
+import {AuthModule} from "../../auth.module";
 
 describe('ValidatorController', () => {
   let controller: ValidatorController;
@@ -46,6 +47,7 @@ describe('ValidatorController', () => {
         UtilsModule,
         ActivityModule,
         CacheModule.register(),
+        AuthModule,
         SequelizeModule.forFeature([Metric]),
         SequelizeModule.forRoot({
           dialect: 'sqlite',

--- a/backend/src/validator/validator.module.ts
+++ b/backend/src/validator/validator.module.ts
@@ -4,9 +4,10 @@ import { ValidatorService } from './validator.service';
 import { UtilsModule } from '../utils/utils.module';
 import { CacheModule } from '@nestjs/cache-manager';
 import { ActivityModule } from '../activity/activity.module';
+import {AuthModule} from "../auth.module";
 
 @Module({
-  imports: [UtilsModule, ActivityModule, CacheModule.register()],
+  imports: [UtilsModule, ActivityModule, CacheModule.register(), AuthModule],
   controllers: [ValidatorController],
   providers: [ValidatorService],
 })

--- a/src/locales/translations/en-US.json
+++ b/src/locales/translations/en-US.json
@@ -32,6 +32,7 @@
   "connect": "Connect",
   "connectWallet": "Connect Wallet",
   "insufficientFunds": "Insufficient Funds",
+  "endSession": "End Session",
   "year": "year",
   "month": "month",
   "week": "week",
@@ -649,6 +650,8 @@
     "invalidPassword": "Invalid password. Please try again.",
     "unableToReach": "Unable to reach backend.",
     "defaultErrorMessage": "Error reaching backend server...",
+    "unableToEndSession": "Unable to end session, please try again.",
+    "unexpectedErrorLogout": "Unexpected error while ending session.",
     "tooltip": {
       "displayName": "Display name for the Siren dashboard",
       "sessionPassword": "Required password set in the configuration file"


### PR DESCRIPTION
https://github.com/sigp/siren/issues/299

Brought up during security review. Users should have a way to manually invalidate their sessions. This pr creates a token blacklist cache for all revoked session tokens. blacklisted tokens only are cached as long as their validation period to prevent build up