### PR TITLE
Fix/default cred type

### DIFF
--- a/src/components/ValidatorManagement/CreateValidatorView/CreateValidatorView.tsx
+++ b/src/components/ValidatorManagement/CreateValidatorView/CreateValidatorView.tsx
@@ -11,6 +11,7 @@ import {
 import { ValidatorCountResult } from '../../../types/validator'
 import HorizontalStepper from '../../HorizontalStepper/HorizontalStepper'
 import CreateValidatorStep from './CreateValidatorStep'
+import MaxEbModal from './MaxEbModal'
 import RiskModal from './RiskModal'
 import KeystoreAuthentication from './Steps/KeystoreAuthentication/KeystoreAuthentication'
 import MnemonicIndex from './Steps/MnemonicIndex/MnemonicIndex'
@@ -109,6 +110,7 @@ const CreateValidatorView: FC<CreateValidatorViewProps> = ({
 
   return (
     <>
+      <MaxEbModal />
       <RiskModal isOpen={isRisk} onAccept={acceptRisk} onClose={dismissRiskMessage} />
       <HorizontalStepper steps={steps}>
         {({ incrementStep, decrementStep, step }) => (

--- a/src/components/ValidatorManagement/CreateValidatorView/MaxEbModal.tsx
+++ b/src/components/ValidatorManagement/CreateValidatorView/MaxEbModal.tsx
@@ -11,7 +11,7 @@ const MaxEbModal = () => {
   const [isOpen, setIsOpen] = useRecoilState(isMaxEBModal)
   const onClose = () => {
     setIsOpen(false)
-    Cookies.set('MaxEBWarningSeen', 'true')
+    Cookies.set('max-eB-warning-seen', 'true')
   }
 
   return (

--- a/src/components/ValidatorManagement/CreateValidatorView/MaxEbModal.tsx
+++ b/src/components/ValidatorManagement/CreateValidatorView/MaxEbModal.tsx
@@ -1,0 +1,32 @@
+import Cookies from 'js-cookie'
+import { useTranslation } from 'react-i18next'
+import { useRecoilState } from 'recoil'
+import { isMaxEBModal } from '../../../recoil/atoms'
+import Button, { ButtonFace } from '../../Button/Button'
+import RodalModal from '../../RodalModal/RodalModal'
+import Typography from '../../Typography/Typography'
+
+const MaxEbModal = () => {
+  const { t } = useTranslation()
+  const [isOpen, setIsOpen] = useRecoilState(isMaxEBModal)
+  const onClose = () => {
+    setIsOpen(false)
+    Cookies.set('MaxEBWarningSeen', 'true')
+  }
+
+  return (
+    <RodalModal onClose={onClose} styles={{ maxWidth: '650px' }} isVisible={isOpen}>
+      <div className='w-full h-full flex flex-col p-6 space-y-6 items-center justify-center'>
+        <i className='bi-exclamation-circle text-6xl text-warning' />
+        <Typography type='text-caption1' className='text-center'>
+          {t('validatorManagement.maxEBModal.text')}
+        </Typography>
+        <Button onClick={onClose} type={ButtonFace.TERTIARY}>
+          {t('understandAndAccept')}
+        </Button>
+      </div>
+    </RodalModal>
+  )
+}
+
+export default MaxEbModal

--- a/src/components/ValidatorManagement/CreateValidatorView/Steps/ValidatorSetup/ValSetupRow.tsx
+++ b/src/components/ValidatorManagement/CreateValidatorView/Steps/ValidatorSetup/ValSetupRow.tsx
@@ -1,9 +1,12 @@
 import { formatEther, parseEther, parseUnits } from 'ethers'
+import Cookies from 'js-cookie'
 import { ChangeEvent, FC } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useSetRecoilState } from 'recoil'
 import addClassString from '../../../../../../utilities/addClassString'
 import { WalletPrefix } from '../../../../../constants/enums'
 import useElectraStatus from '../../../../../hooks/useElectraStatus'
+import { isMaxEBModal } from '../../../../../recoil/atoms'
 import { ValidatorCandidate } from '../../../../../types'
 import IconButton, { IconButtonTypes } from '../../../../IconButton/IconButton'
 import Input from '../../../../Input/Input'
@@ -28,6 +31,7 @@ const ValSetupRow: FC<ValSetupRowProps> = ({
   onRemoveCandidate,
 }) => {
   const { t } = useTranslation()
+  const setIsMaxEBModal = useSetRecoilState(isMaxEBModal)
   const { id, withdrawalPrefix, effectiveBalance } = candidate
   const removeCandidate = () => onRemoveCandidate(id)
   const { isEnabled } = useElectraStatus()
@@ -49,6 +53,11 @@ const ValSetupRow: FC<ValSetupRowProps> = ({
     if (!value) {
       effectiveBalance = parseUnits(minActivationBalance.toString(), 'gwei')
     }
+
+    if (value && Cookies.get('max-eB-warning-seen') !== 'true') {
+      setIsMaxEBModal(true)
+    }
+
     onUpdateCandidate(id, {
       ...candidate,
       withdrawalPrefix: withdrawalPrefix === WalletPrefix.TWO ? WalletPrefix.ONE : WalletPrefix.TWO,

--- a/src/components/ValidatorManagement/CreateValidatorView/Steps/ValidatorSetup/ValidatorSetup.tsx
+++ b/src/components/ValidatorManagement/CreateValidatorView/Steps/ValidatorSetup/ValidatorSetup.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next'
 import { v4 as uuidv4 } from 'uuid'
 import displayToast from '../../../../../../utilities/displayToast'
 import { WalletPrefix } from '../../../../../constants/enums'
-import useElectraStatus from '../../../../../hooks/useElectraStatus'
 import { ToastType, ValidatorCandidate } from '../../../../../types'
 import Typography from '../../../../Typography/Typography'
 import StepOptions, { StepOptionsProps } from '../../StepOptions'
@@ -26,9 +25,8 @@ const ValidatorSetup: FC<ValidatorSetupProps> = ({
   const { t } = useTranslation()
   const getRandomId = () => uuidv4().toString()
 
-  const { isEnabled } = useElectraStatus()
   const baseDefaultValidator = {
-    withdrawalPrefix: isEnabled ? WalletPrefix.TWO : WalletPrefix.ONE,
+    withdrawalPrefix: WalletPrefix.ONE,
     effectiveBalance: parseUnits(minActivationBalance.toString(), 'gwei'),
     index: undefined,
     keyStorePassword: undefined,

--- a/src/locales/translations/en-US.json
+++ b/src/locales/translations/en-US.json
@@ -356,6 +356,9 @@
     "overview": "Overview",
     "day": "Day",
     "invalidMnemonic": "Invalid mnemonic phrase. Please review and try again.",
+    "maxEBModal": {
+      "text": "Enabling Max EB 0x02 withdrawal credentials means your validator will have the ability to hold up to 2048 ETH in its max effective balance. It will also mean your validator will no longer automatically make partial withdrawals of any rewards accumulated, unless rewards exceed 2048 ETH. Additionally, 0x02 withdrawal credentials mean you will be required to send a request to the Beacon Node to withdraw any amount of ETH as long as the validator remains at or above 32 ETh."
+    },
     "effectiveness": {
       "targetVote": "Target Vote",
       "headVote": "Head Vote",

--- a/src/recoil/atoms.ts
+++ b/src/recoil/atoms.ts
@@ -119,3 +119,8 @@ export const blsModuleAtom = atom<IBls | undefined>({
   key: 'blsModuleAtom',
   default: undefined,
 })
+
+export const isMaxEBModal = atom<boolean>({
+  key: 'isMaxEBModal',
+  default: false,
+})


### PR DESCRIPTION
New deposits will remain default 0x01 after pectra fork. If users toggle 0x02 they will see a informational modal explaining what it means.