### PR TITLE
Fix/mnemonic validation

### DIFF
--- a/src/components/ValidatorManagement/CreateValidatorView/Steps/MnemonicPhrase.tsx
+++ b/src/components/ValidatorManagement/CreateValidatorView/Steps/MnemonicPhrase.tsx
@@ -4,12 +4,15 @@ import { useTranslation } from 'react-i18next'
 import { useRecoilValue } from 'recoil'
 import addClassString from '../../../../../utilities/addClassString'
 import displayToast from '../../../../../utilities/displayToast'
+import getMnemonicStats from '../../../../../utilities/getMnemonicStats'
+import getWordLength from '../../../../../utilities/getWordLength'
 import useChainSafeKeygen from '../../../../hooks/useChainSafeKeygen'
 import { blsModuleAtom } from '../../../../recoil/atoms'
 import { ToastType } from '../../../../types'
 import InfoBox, { InfoBoxType } from '../../../InfoBox/InfoBox'
 import Spinner from '../../../Spinner/Spinner'
 import Typography from '../../../Typography/Typography'
+import WordCountDisplay from '../../../WordCountDisplay/WordCountDisplay'
 import StepOptions from '../StepOptions'
 
 export interface MnemonicPhraseProps extends InputHTMLAttributes<HTMLTextAreaElement> {
@@ -72,15 +75,17 @@ const MnemonicPhrase: FC<MnemonicPhraseProps> = ({
       void validateKeyPhrase(phrase)
     }, 1000),
   )
+  const wordCount = getWordLength(String(value))
+  const { limit, color, isValid } = getMnemonicStats(wordCount)
 
   useEffect(() => {
     setIsValidated(false)
-    if (!value) {
+    if (!value || !isValid) {
       return
     }
 
     debouncedValidateKeyPhraseRef.current(value as string)
-  }, [value])
+  }, [value, isValid])
 
   return (
     <div className='w-full h-full space-y-6'>
@@ -101,7 +106,9 @@ const MnemonicPhrase: FC<MnemonicPhraseProps> = ({
           </div>
         </InfoBox>
         <div className='relative'>
-          {value && !isValidated && <Spinner size='w-6 h-6' className='absolute top-2 right-0' />}
+          {value && !isValidated && isValid && (
+            <Spinner size='w-6 h-6' className='absolute top-2 right-0' />
+          )}
           <textarea
             onChange={onChange}
             placeholder={t('validatorManagement.mnemonicPhrase.placeholder')}
@@ -109,6 +116,7 @@ const MnemonicPhrase: FC<MnemonicPhraseProps> = ({
             cols={30}
             rows={10}
           />
+          <WordCountDisplay count={wordCount} limit={limit} color={color} />
         </div>
       </div>
       <StepOptions

--- a/src/components/ValidatorModal/views/ValidatorDeposit/ValidatorDeposit.tsx
+++ b/src/components/ValidatorModal/views/ValidatorDeposit/ValidatorDeposit.tsx
@@ -13,6 +13,8 @@ import React, {
 import { useTranslation } from 'react-i18next'
 import { useRecoilValue } from 'recoil'
 import displayToast from '../../../../../utilities/displayToast'
+import getMnemonicStats from '../../../../../utilities/getMnemonicStats'
+import getWordLength from '../../../../../utilities/getWordLength'
 import {
   EFFECTIVE_BALANCE,
   MAX_BALANCE_INPUT,
@@ -85,6 +87,9 @@ const ValidatorDeposit: FC<ValidatorDepositProps> = ({ validator, validatorEpoch
     }
   }, [])
 
+  const wordCount = getWordLength(String(mnemonic))
+  const { isValid } = getMnemonicStats(wordCount)
+
   const debouncedValidateKeyPhraseRef = useRef(
     debounce((mnemonic: string) => {
       void validateMnemonic(mnemonic)
@@ -93,10 +98,10 @@ const ValidatorDeposit: FC<ValidatorDepositProps> = ({ validator, validatorEpoch
 
   useEffect(() => {
     setIsValidated(false)
-    if (!mnemonic) return
+    if (!mnemonic || !isValid) return
 
     debouncedValidateKeyPhraseRef.current(mnemonic)
-  }, [mnemonic])
+  }, [mnemonic, isValid])
 
   useEffect(() => {
     if (!mnemonic || mnemonicIndex === null || !isValidMnemonic) return

--- a/src/components/ValidatorModal/views/ValidatorDeposit/steps/ValidateIndex.tsx
+++ b/src/components/ValidatorModal/views/ValidatorDeposit/steps/ValidateIndex.tsx
@@ -106,7 +106,7 @@ const ValidateIndex: FC<ValidateIndexProps> = ({ mnemonic, pubKey, onVerifyIndex
               max={MAX_MNEMONIC_INDEX}
               type='number'
             />
-            {!isValidated && !isValidIndex && mnemonicIndex && (
+            {!isValidated && !isValidIndex && !!mnemonicIndex && (
               <div className='absolute top-1/2 -translate-y-1/2 right-1'>
                 <Spinner size='h-4 w-4' />
               </div>

--- a/src/components/ValidatorModal/views/ValidatorDeposit/steps/ValidateMnemonic.tsx
+++ b/src/components/ValidatorModal/views/ValidatorDeposit/steps/ValidateMnemonic.tsx
@@ -1,7 +1,10 @@
 import clsx from 'clsx'
 import { FC, InputHTMLAttributes } from 'react'
 import { useTranslation } from 'react-i18next'
+import getMnemonicStats from '../../../../../../utilities/getMnemonicStats'
+import getWordLength from '../../../../../../utilities/getWordLength'
 import Spinner from '../../../../Spinner/Spinner'
+import WordCountDisplay from '../../../../WordCountDisplay/WordCountDisplay'
 
 export interface ValidateMnemonicProps extends InputHTMLAttributes<HTMLTextAreaElement> {
   isValidKeyPhrase: boolean
@@ -16,6 +19,8 @@ const ValidateMnemonic: FC<ValidateMnemonicProps> = ({
   disabled,
 }) => {
   const { t } = useTranslation()
+  const wordCount = getWordLength(String(value))
+  const { limit, color, isValid } = getMnemonicStats(wordCount)
 
   const textAreaClasses = clsx(
     'w-full text-dark900 dark:bg-dark600_20 dark:text-dark300 font-openSauce text-caption1 p-4 outline-none bg-transparent rounded-sm border pr-12',
@@ -24,7 +29,9 @@ const ValidateMnemonic: FC<ValidateMnemonicProps> = ({
 
   return (
     <div className='relative'>
-      {value && !isValidated && <Spinner size='w-6 h-6' className='absolute top-2 right-0' />}
+      {value && !isValidated && isValid && (
+        <Spinner size='w-6 h-6' className='absolute top-2 right-0' />
+      )}
       <textarea
         onChange={onChange}
         disabled={disabled}
@@ -33,6 +40,7 @@ const ValidateMnemonic: FC<ValidateMnemonicProps> = ({
         cols={30}
         rows={10}
       />
+      <WordCountDisplay count={wordCount} limit={limit} color={color} />
     </div>
   )
 }

--- a/src/components/WordCountDisplay/WordCountDisplay.tsx
+++ b/src/components/WordCountDisplay/WordCountDisplay.tsx
@@ -1,0 +1,23 @@
+import { FC } from 'react'
+import Typography, { TypographyProps } from '../Typography/Typography'
+
+export interface WordCountDisplayProps extends Pick<TypographyProps, 'color'> {
+  count: number
+  limit: number
+}
+
+const WordCountDisplay: FC<WordCountDisplayProps> = ({ count, limit, color }) => {
+  return (
+    <div className='w-full flex justify-end'>
+      <Typography
+        color={color}
+        darkMode={color ? `dark:${color}` : undefined}
+        type='text-caption1.5'
+      >
+        {count} / {limit}
+      </Typography>
+    </div>
+  )
+}
+
+export default WordCountDisplay

--- a/utilities/getMnemonicStats.ts
+++ b/utilities/getMnemonicStats.ts
@@ -1,0 +1,17 @@
+import {TypographyColor} from "../src/components/Typography/Typography";
+
+const getMnemonicStats = (wordCount: number): {limit: number, color: TypographyColor, isValid: boolean} => {
+  const validMnemonicLengths = [12,15,18,21,24]
+
+  const limit = validMnemonicLengths.find(x => x >= wordCount) || validMnemonicLengths[validMnemonicLengths.length - 1]
+  const color = wordCount === limit ? 'text-success' : wordCount > limit ? 'text-error' : undefined as TypographyColor
+  const isValid = validMnemonicLengths.includes(wordCount)
+
+  return {
+    limit,
+    color,
+    isValid
+  }
+}
+
+export default getMnemonicStats

--- a/utilities/getWordLength.ts
+++ b/utilities/getWordLength.ts
@@ -1,0 +1,5 @@
+const getWordLength = (value: string | undefined): number => {
+  return value ? value.trim().split(' ').length : 0
+}
+
+export default getWordLength


### PR DESCRIPTION
Mainnet users will likely hand type their mnemonic phrases into input fields. This pr removes the validation per keystroke and instead only validates valid mnemonic lengths to reduce redundant validations

https://github.com/sigp/siren/issues/336