### PR TITLE
Fix/wallet validation

### DIFF
--- a/app/dashboard/validators/Main.tsx
+++ b/app/dashboard/validators/Main.tsx
@@ -190,7 +190,8 @@ const Main: FC<MainProps> = (props) => {
   const eligibleToConsolidate = useMemo(() => {
     return validatorStates.filter(
       ({ withdrawalAddress }) =>
-        withdrawalAddress.includes('0x01') || withdrawalAddress.includes('0x02'),
+        !!withdrawalAddress &&
+        (withdrawalAddress.includes('0x01') || withdrawalAddress.includes('0x02')),
     )
   }, [validatorStates])
 

--- a/src/components/ValidatorCredentialRow/ValidatorCredentialRow.tsx
+++ b/src/components/ValidatorCredentialRow/ValidatorCredentialRow.tsx
@@ -3,7 +3,7 @@ import { ChangeEvent, FC, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSignMessage } from 'wagmi'
 import addClassString from '../../../utilities/addClassString'
-import { ValidatorCandidate } from '../../types'
+import { Address, ValidatorCandidate } from '../../types'
 import Button, { ButtonFace } from '../Button/Button'
 import Typography from '../Typography/Typography'
 import ValidatorCandidateRow from '../ValidatorCandidateRow/ValidatorCandidateRow'
@@ -87,7 +87,6 @@ const ValidatorCredentialRow: FC<ValidatorCredentialRowProps> = ({
 
   useEffect(() => {
     if (error) {
-      console.log(error)
       setLoading(false)
     }
   }, [error])
@@ -121,7 +120,10 @@ const ValidatorCredentialRow: FC<ValidatorCredentialRowProps> = ({
           </div>
           {!isVerifiedCredentials ? (
             <div className='full'>
-              <WalletActionGuard textSize='text-caption1'>
+              <WalletActionGuard
+                targetAddress={credentialInput as Address}
+                textSize='text-caption1'
+              >
                 <Button
                   padding='px-4 py-1'
                   className='py-1'

--- a/utilities/getMnemonicStats.ts
+++ b/utilities/getMnemonicStats.ts
@@ -4,7 +4,7 @@ const getMnemonicStats = (wordCount: number): {limit: number, color: TypographyC
   const validMnemonicLengths = [12,15,18,21,24]
 
   const limit = validMnemonicLengths.find(x => x >= wordCount) || validMnemonicLengths[validMnemonicLengths.length - 1]
-  const color = wordCount === limit ? 'text-success' : wordCount > limit ? 'text-error' : undefined as TypographyColor
+  const color = (wordCount === limit ? 'text-success' : wordCount > limit ? 'text-error' : undefined) as TypographyColor
   const isValid = validMnemonicLengths.includes(wordCount)
 
   return {


### PR DESCRIPTION
On withdrawal credential step in the depoit flow users could enter a wallet address that is not connected to siren. this would cause them to always have an incorrect signature. Add validation for verifying only when the wallet input matches the connected wallet. https://github.com/sigp/siren/issues/340