### PR TITLE
Fix/import validator

### DIFF
--- a/src/components/ValidatorCredentialRow/CredentialInput.tsx
+++ b/src/components/ValidatorCredentialRow/CredentialInput.tsx
@@ -1,0 +1,147 @@
+import clsx from 'clsx'
+import { getAddress, verifyMessage } from 'ethers'
+import { ChangeEvent, FC, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useSignMessage } from 'wagmi'
+import { Address } from '../../types'
+import Button, { ButtonFace } from '../Button/Button'
+import Typography from '../Typography/Typography'
+import WalletActionGuard from '../WalletActionGuard/WalletActionGuard'
+
+export interface CredentialInputProps {
+  label?: string | undefined
+  id: string
+  value: string | undefined
+  isVerifiedCredentials: boolean
+  onVerify: (value: boolean) => void
+  onChange: (value: string | undefined) => void
+}
+
+const CredentialInput: FC<CredentialInputProps> = ({
+  label,
+  id,
+  isVerifiedCredentials,
+  value,
+  onVerify,
+  onChange,
+}) => {
+  const { t } = useTranslation()
+  const [errorMsg, setError] = useState('')
+  const [isLoading, setLoading] = useState(false)
+  const [isValidAddress, setIsValidAddress] = useState(false)
+  const messageSignature = t('validatorManagement.withdrawalCredentials.confirmOwnership')
+  const { data, signMessage, error, reset } = useSignMessage()
+  const containerClasses = clsx('w-full relative flex items-center pr-4')
+  const inputClasses = clsx(
+    'w-full h-full text-dark900 dark:text-dark300 dark:bg-dark600_20 font-openSauce text-caption1 p-2 outline-none bg-transparent border',
+    errorMsg ? 'border-error100' : 'border-style',
+  )
+
+  const handleError = (e: any) => {
+    let message = 'error.unexpectedAddressError'
+
+    if (e?.code === 'INVALID_ARGUMENT') {
+      message = 'error.invalidAddressFormat'
+    }
+
+    setError(t(message))
+  }
+
+  const verifyCredentials = () => {
+    setLoading(true)
+    setError('')
+    signMessage({ message: messageSignature })
+  }
+
+  const setCredential = (e: ChangeEvent<HTMLInputElement>) => {
+    onChange(undefined)
+    setError('')
+    setIsValidAddress(false)
+    reset()
+
+    try {
+      const value = e.target.value
+      onChange(getAddress(value))
+      setIsValidAddress(true)
+    } catch (e) {
+      handleError(e)
+    }
+  }
+
+  useEffect(() => {
+    if (!data || !value) return
+
+    try {
+      const signedAddress = verifyMessage(messageSignature, data)
+      const checkSumAddress = getAddress(value)
+      const isVerifiedCredentials = signedAddress === checkSumAddress
+
+      onVerify(isVerifiedCredentials)
+
+      if (!isVerifiedCredentials) {
+        setError(t('validatorManagement.withdrawalCredentials.incorrectSignature'))
+      }
+    } catch (e) {
+      handleError(e)
+    } finally {
+      setLoading(false)
+    }
+  }, [data, t, value])
+
+  useEffect(() => {
+    if (error) {
+      setLoading(false)
+    }
+  }, [error])
+
+  return (
+    <div className='w-full space-y-2'>
+      {!!label && (
+        <label htmlFor={id}>
+          <Typography type='text-caption1.5'>{label}</Typography>
+        </label>
+      )}
+      <div className={containerClasses}>
+        <div className='flex h-[32px] w-full h-full items-center'>
+          <div className='w-full relative'>
+            <input
+              id={id}
+              value={value}
+              onChange={setCredential}
+              className={inputClasses}
+              type='text'
+            />
+            {isVerifiedCredentials && (
+              <i className='bi-check-lg absolute right-5 text-success top-1/2 -translate-y-1/2' />
+            )}
+          </div>
+          {!isVerifiedCredentials ? (
+            <div className='full'>
+              <WalletActionGuard targetAddress={value as Address} textSize='text-caption1'>
+                <Button
+                  padding='px-4 py-1'
+                  className='py-1'
+                  isLoading={isLoading}
+                  isDisabled={!value || !isValidAddress}
+                  onClick={verifyCredentials}
+                  type={ButtonFace.TERTIARY}
+                >
+                  {t('verify')}
+                </Button>
+              </WalletActionGuard>
+            </div>
+          ) : null}
+        </div>
+      </div>
+      {errorMsg ? (
+        <div className=''>
+          <Typography color='text-error' darkMode='dark:text-error' type='text-caption1.5'>
+            {errorMsg}
+          </Typography>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export default CredentialInput

--- a/src/components/ValidatorCredentialRow/ValidatorCredentialRow.tsx
+++ b/src/components/ValidatorCredentialRow/ValidatorCredentialRow.tsx
@@ -1,153 +1,87 @@
-import { getAddress, verifyMessage } from 'ethers'
-import { ChangeEvent, FC, useEffect, useState } from 'react'
-import { useTranslation } from 'react-i18next'
-import { useSignMessage } from 'wagmi'
-import addClassString from '../../../utilities/addClassString'
-import { Address, ValidatorCandidate } from '../../types'
-import Button, { ButtonFace } from '../Button/Button'
-import Typography from '../Typography/Typography'
+import { FC, memo } from 'react'
+import { ValidatorCandidate } from '../../types'
 import ValidatorCandidateRow from '../ValidatorCandidateRow/ValidatorCandidateRow'
-import WalletActionGuard from '../WalletActionGuard/WalletActionGuard'
+import CredentialInput from './CredentialInput'
 
 export interface ValidatorCredentialRowProps {
   validatorCandidate: ValidatorCandidate
   onUpdateCandidate: (id: string, candidate: ValidatorCandidate) => void
+  isAdvanceView: boolean
 }
 
 const ValidatorCredentialRow: FC<ValidatorCredentialRowProps> = ({
   validatorCandidate,
   onUpdateCandidate,
+  isAdvanceView,
 }) => {
-  const { t } = useTranslation()
-  const { id, index, isVerifiedCredentials } = validatorCandidate
-  const [credentialInput, setCredentialInput] = useState('')
-  const [isLoading, setLoading] = useState(false)
-  const [isValidAddress, setIsValidAddress] = useState(false)
-  const [errorMsg, setError] = useState('')
-  const messageSignature = t('validatorManagement.withdrawalCredentials.confirmOwnership')
-
-  const { data, signMessage, error, reset } = useSignMessage()
-
-  const handleError = (e: any) => {
-    let message = 'error.unexpectedAddressError'
-
-    if (e?.code === 'INVALID_ARGUMENT') {
-      message = 'error.invalidAddressFormat'
-    }
-
-    setError(t(message))
+  const {
+    id,
+    index,
+    isVerifiedCredentials,
+    isVerifiedSuggestedFee,
+    withdrawalCredentials,
+    suggestedFeeRecipient,
+  } = validatorCandidate
+  const setCredential = (value: string | undefined) => {
+    onUpdateCandidate(
+      id,
+      isAdvanceView
+        ? { ...validatorCandidate, withdrawalCredentials: value, isVerifiedCredentials: false } // if advanced view only set withdrawal
+        : {
+            ...validatorCandidate,
+            withdrawalCredentials: value,
+            suggestedFeeRecipient: value,
+            isVerifiedCredentials: false,
+            isVerifiedSuggestedFee: false,
+          }, // if basic view set both withdrawal and suggested fee to same value
+    )
   }
 
-  const setCredential = (e: ChangeEvent<HTMLInputElement>) => {
+  const verifyWithdrawalCredential = (value: boolean) => {
+    onUpdateCandidate(
+      id,
+      isAdvanceView
+        ? { ...validatorCandidate, isVerifiedCredentials: value } // if advanced view set only withdrawal
+        : { ...validatorCandidate, isVerifiedCredentials: value, isVerifiedSuggestedFee: value }, // if basic view set both withdrawal and suggested fee to same value
+    )
+  }
+
+  const setSuggestedFee = (value: string | undefined) => {
     onUpdateCandidate(id, {
       ...validatorCandidate,
-      withdrawalCredentials: undefined,
-      isVerifiedCredentials: false,
+      suggestedFeeRecipient: value,
+      isVerifiedSuggestedFee: false,
     })
-    setError('')
-    setIsValidAddress(false)
-    reset()
-
-    try {
-      const value = e.target.value
-      setCredentialInput(value)
-      const checkSumAddress = getAddress(value)
-      onUpdateCandidate(id, { ...validatorCandidate, withdrawalCredentials: checkSumAddress })
-      setIsValidAddress(true)
-    } catch (e) {
-      handleError(e)
-    }
   }
 
-  const verifyCredentials = () => {
-    setLoading(true)
-    setError('')
-    signMessage({ message: messageSignature })
+  const verifySuggestedFee = (value: boolean) => {
+    onUpdateCandidate(id, { ...validatorCandidate, isVerifiedSuggestedFee: value })
   }
-
-  useEffect(() => {
-    if (!data) return
-
-    try {
-      const signedAddress = verifyMessage(messageSignature, data)
-      const checkSumAddress = getAddress(credentialInput)
-      const isVerifiedCredentials = signedAddress === checkSumAddress
-
-      onUpdateCandidate(id, { ...validatorCandidate, isVerifiedCredentials })
-
-      if (!isVerifiedCredentials) {
-        setError(t('validatorManagement.withdrawalCredentials.incorrectSignature'))
-      }
-    } catch (e) {
-      handleError(e)
-    } finally {
-      setLoading(false)
-    }
-  }, [data, t, credentialInput])
-
-  useEffect(() => {
-    if (error) {
-      setLoading(false)
-    }
-  }, [error])
-
-  const inputClasses = addClassString(
-    'w-full h-full text-dark900 dark:text-dark300 dark:bg-dark600_20 font-openSauce text-caption1 p-2 outline-none bg-transparent border-style',
-    [errorMsg && 'border-error'],
-  )
-  const containerClasses = addClassString('w-full relative flex items-center max-w-[500px] pr-4', [
-    errorMsg && 'h-24',
-  ])
 
   return (
-    <ValidatorCandidateRow
-      isError={Boolean(errorMsg)}
-      data={validatorCandidate}
-      index={index ? Number(index) : undefined}
-    >
-      <div className={containerClasses}>
-        <div className='flex h-[32px] w-full h-full items-center'>
-          <div className='w-full relative'>
-            <input
-              value={credentialInput}
-              onChange={setCredential}
-              className={inputClasses}
-              type='text'
-            />
-            {isVerifiedCredentials && (
-              <i className='bi-check-lg absolute right-5 text-success top-1/2 -translate-y-1/2' />
-            )}
-          </div>
-          {!isVerifiedCredentials ? (
-            <div className='full'>
-              <WalletActionGuard
-                targetAddress={credentialInput as Address}
-                textSize='text-caption1'
-              >
-                <Button
-                  padding='px-4 py-1'
-                  className='py-1'
-                  isLoading={isLoading}
-                  isDisabled={!credentialInput || !isValidAddress}
-                  onClick={verifyCredentials}
-                  type={ButtonFace.TERTIARY}
-                >
-                  {t('verify')}
-                </Button>
-              </WalletActionGuard>
-            </div>
-          ) : null}
-        </div>
-        {errorMsg ? (
-          <div className='absolute bottom-1 left-0'>
-            <Typography color='text-error' darkMode='dark:text-error' type='text-caption1'>
-              {errorMsg}
-            </Typography>
-          </div>
-        ) : null}
+    <ValidatorCandidateRow data={validatorCandidate} index={index ? Number(index) : undefined}>
+      <div className='w-full px-2 py-4 space-y-4 max-w-[500px]'>
+        <CredentialInput
+          id={`withdrawalCredentialInput-${index}`}
+          value={withdrawalCredentials}
+          label={isAdvanceView ? 'Withdrawal Credentials' : undefined}
+          onChange={setCredential}
+          onVerify={verifyWithdrawalCredential}
+          isVerifiedCredentials={Boolean(isVerifiedCredentials)}
+        />
+        {isAdvanceView && (
+          <CredentialInput
+            id={`suggestedFeeInput-${index}`}
+            value={suggestedFeeRecipient}
+            label={isAdvanceView ? 'Suggested Fee Recipient' : undefined}
+            onChange={setSuggestedFee}
+            onVerify={verifySuggestedFee}
+            isVerifiedCredentials={Boolean(isVerifiedSuggestedFee)}
+          />
+        )}
       </div>
     </ValidatorCandidateRow>
   )
 }
 
-export default ValidatorCredentialRow
+export default memo(ValidatorCredentialRow)

--- a/src/components/ValidatorDepositImport/ValidatorDepositImport.spec.tsx
+++ b/src/components/ValidatorDepositImport/ValidatorDepositImport.spec.tsx
@@ -36,6 +36,7 @@ describe('ValidatorDepositImport', () => {
     txHash: '0x123' as `0x${string}`,
     pubKey: '0x456789abcdef123456789abcdef123456789abcdef' as `0x${string}`,
     mnemonicIndex: 0,
+    suggestedFeeRecipient: '0xsuggestedFeeRecipient',
     keyStorePassword: 'password',
     status: 'pending' as TxStatus,
   }
@@ -217,6 +218,7 @@ describe('ValidatorDepositImport', () => {
         mnemonic,
         index: depositData.mnemonicIndex,
         keyStorePassword: depositData.keyStorePassword,
+        suggestedFeeRecipient: '0xsuggestedFeeRecipient',
         onSuccess: expect.any(Function),
         onError: expect.any(Function),
       })

--- a/src/components/ValidatorDepositImport/ValidatorDepositImport.tsx
+++ b/src/components/ValidatorDepositImport/ValidatorDepositImport.tsx
@@ -26,7 +26,8 @@ const ValidatorDepositImport: FC<ValidatorDepositImportProps> = ({
   depositNetworkId,
 }) => {
   const { t } = useTranslation()
-  const { txHash, pubKey, mnemonicIndex, keyStorePassword, status } = depositData
+  const { txHash, pubKey, mnemonicIndex, keyStorePassword, suggestedFeeRecipient, status } =
+    depositData
   const shortHandPubKey = formatEthAddress(pubKey)
   const { txStatus } = useResolveTransactionOnce(txHash)
   const {
@@ -52,6 +53,7 @@ const ValidatorDepositImport: FC<ValidatorDepositImportProps> = ({
         mnemonic,
         index: mnemonicIndex,
         keyStorePassword,
+        suggestedFeeRecipient,
         onSuccess: () => {
           onUpdateStatus(pubKey, 'success')
         },
@@ -60,7 +62,7 @@ const ValidatorDepositImport: FC<ValidatorDepositImportProps> = ({
         },
       })
     })()
-  }, [txStatus, mnemonic, mnemonicIndex, keyStorePassword, pubKey, status])
+  }, [txStatus, mnemonic, mnemonicIndex, keyStorePassword, suggestedFeeRecipient, pubKey, status])
 
   const beaconChaLink = isValidNetwork(depositNetworkId)
     ? getBeaconChaLink(depositNetworkId, `/validator/${pubKey}`)

--- a/src/components/ValidatorDepositRow/ValidatorDepositRow.tsx
+++ b/src/components/ValidatorDepositRow/ValidatorDepositRow.tsx
@@ -19,6 +19,7 @@ export interface ValidatorDepositRowProps extends Omit<ValidatorDepositConfig, '
     keyStorePassword: string,
     pubKey: string,
     mnemonicIndex: number,
+    suggestedFeeRecipient: string,
   ) => void
   data: DepositData | undefined
 }
@@ -31,7 +32,13 @@ const ValidatorDepositRow: FC<ValidatorDepositRowProps> = ({
   data,
 }) => {
   const { t } = useTranslation()
-  const { index, effectiveBalance, pubKey: candidatePubKey, keyStorePassword } = candidate
+  const {
+    index,
+    effectiveBalance,
+    pubKey: candidatePubKey,
+    keyStorePassword,
+    suggestedFeeRecipient,
+  } = candidate
   const { isLoading, txHash, error, pubKey, makeDeposit } = useValidatorDeposit({
     validator: candidate,
     mnemonic,
@@ -41,9 +48,9 @@ const ValidatorDepositRow: FC<ValidatorDepositRowProps> = ({
 
   useEffect(() => {
     if (txHash && pubKey && !!keyStorePassword) {
-      onDeposit(txHash, keyStorePassword, pubKey, index as number)
+      onDeposit(txHash, keyStorePassword, pubKey, index as number, suggestedFeeRecipient as string)
     }
-  }, [txHash, keyStorePassword, pubKey, index])
+  }, [txHash, keyStorePassword, pubKey, index, suggestedFeeRecipient])
 
   useEffect(() => {
     if (error) {

--- a/src/components/ValidatorManagement/CreateValidatorView/CreateValidatorView.tsx
+++ b/src/components/ValidatorManagement/CreateValidatorView/CreateValidatorView.tsx
@@ -51,7 +51,8 @@ const CreateValidatorView: FC<CreateValidatorViewProps> = ({
 
   const [candidates, setValidatorCandidates] = useState<ValidatorCandidate[]>([])
   const [keyPhrase, setKeyPhrase] = useState('')
-  const [sharedWithdrawalCredentials, setSharedCredentials] = useState<string | undefined>()
+  const [sharedWithdrawalCredentials, setSharedCredentials] = useState<string | undefined>('')
+  const [sharedSuggestedFee, setSharedSuggestedFee] = useState<string | undefined>('')
   const [sharedKeystorePassword, setSharedKeystorePassword] = useState<string | undefined>(
     undefined,
   )
@@ -84,8 +85,12 @@ const CreateValidatorView: FC<CreateValidatorViewProps> = ({
     setKeyPhrase(e.target.value)
   }, [])
 
-  const updateSharedCredentials = useCallback((credentials?: string) => {
+  const updateSharedCredentials = useCallback((credentials: string | undefined) => {
     setSharedCredentials(credentials)
+  }, [])
+
+  const updateSharedSuggestedFee = useCallback((suggestedFee: string | undefined) => {
+    setSharedSuggestedFee(suggestedFee)
   }, [])
 
   const setKeystorePassword = useCallback((password: string | undefined) => {
@@ -116,102 +121,107 @@ const CreateValidatorView: FC<CreateValidatorViewProps> = ({
       <RiskModal isOpen={isRisk} onAccept={acceptRisk} onClose={dismissRiskMessage} />
       {blsModule ? (
         <HorizontalStepper steps={steps}>
-          {({ incrementStep, decrementStep, step }) => (
-            <>
-              <CreateValidatorStep
-                requiredStake={requiredStake}
-                rewardEstimate={calculatedRewards}
-                candidateCount={totalCandidates}
-              >
-                {MIN_ACTIVATION_BALANCE && (
-                  <ValidatorSetup
-                    onNextStep={incrementStep}
-                    onValidatorChange={setNewValidators}
-                    minActivationBalance={MIN_ACTIVATION_BALANCE}
-                    candidates={candidates}
-                  />
-                )}
-              </CreateValidatorStep>
-
-              <CreateValidatorStep
-                requiredStake={requiredStake}
-                rewardEstimate={calculatedRewards}
-                candidateCount={totalCandidates}
-              >
-                <MnemonicPhrase
-                  isActive={step === 1}
-                  onNextStep={incrementStep}
-                  value={keyPhrase}
-                  onChange={setPhrase}
-                  onBackStep={decrementStep}
-                  blsModule={blsModule}
-                />
-              </CreateValidatorStep>
-
-              {DEPOSIT_NETWORK_ID && (
+          {({ incrementStep, decrementStep, step }) =>
+            (
+              <>
                 <CreateValidatorStep
                   requiredStake={requiredStake}
                   rewardEstimate={calculatedRewards}
                   candidateCount={totalCandidates}
                 >
-                  <MnemonicIndex
-                    depositNetworkId={DEPOSIT_NETWORK_ID}
-                    isActive={step === 2}
-                    onBackStep={decrementStep}
-                    onValidatorChange={setNewValidators}
+                  {MIN_ACTIVATION_BALANCE && (
+                    <ValidatorSetup
+                      onNextStep={incrementStep}
+                      onValidatorChange={setNewValidators}
+                      minActivationBalance={MIN_ACTIVATION_BALANCE}
+                      candidates={candidates}
+                    />
+                  )}
+                </CreateValidatorStep>
+
+                <CreateValidatorStep
+                  requiredStake={requiredStake}
+                  rewardEstimate={calculatedRewards}
+                  candidateCount={totalCandidates}
+                >
+                  <MnemonicPhrase
+                    isActive={step === 1}
                     onNextStep={incrementStep}
-                    keyPhrase={keyPhrase}
-                    candidates={candidates}
+                    value={keyPhrase}
+                    onChange={setPhrase}
+                    onBackStep={decrementStep}
+                    blsModule={blsModule}
                   />
                 </CreateValidatorStep>
-              )}
 
-              <CreateValidatorStep
-                requiredStake={requiredStake}
-                rewardEstimate={calculatedRewards}
-                candidateCount={totalCandidates}
-              >
-                <WithdrawalCredentials
-                  onShowRisk={showRiskMessage}
-                  hasAcceptedRisk={hasAcceptedRisk}
-                  isActive={step === 3}
-                  candidates={candidates}
-                  onValidatorChange={setNewValidators}
-                  onBackStep={decrementStep}
-                  onNextStep={incrementStep}
-                  onUpdateSharedCredentials={updateSharedCredentials}
-                  sharedCredentials={sharedWithdrawalCredentials}
-                />
-              </CreateValidatorStep>
+                {DEPOSIT_NETWORK_ID && (
+                  <CreateValidatorStep
+                    requiredStake={requiredStake}
+                    rewardEstimate={calculatedRewards}
+                    candidateCount={totalCandidates}
+                  >
+                    <MnemonicIndex
+                      depositNetworkId={DEPOSIT_NETWORK_ID}
+                      isActive={step === 2}
+                      onBackStep={decrementStep}
+                      onValidatorChange={setNewValidators}
+                      onNextStep={incrementStep}
+                      keyPhrase={keyPhrase}
+                      candidates={candidates}
+                    />
+                  </CreateValidatorStep>
+                )}
 
-              <CreateValidatorStep
-                requiredStake={requiredStake}
-                rewardEstimate={calculatedRewards}
-                candidateCount={totalCandidates}
-              >
-                <KeystoreAuthentication
-                  onUpdateCandidates={setNewValidators}
-                  sharedKeystorePassword={sharedKeystorePassword}
-                  setSharedKeystorePassword={setKeystorePassword}
-                  candidates={candidates}
-                  onBackStep={decrementStep}
-                  onNextStep={incrementStep}
-                />
-              </CreateValidatorStep>
-
-              {Boolean(candidates.length) && beaconSpec && (
-                <SignDeposit
-                  sharedKeystorePassword={sharedKeystorePassword}
-                  beaconSpec={beaconSpec}
-                  sharedWithdrawalCredentials={sharedWithdrawalCredentials}
-                  onComplete={viewManagement}
+                <CreateValidatorStep
+                  requiredStake={requiredStake}
                   rewardEstimate={calculatedRewards}
-                  mnemonic={keyPhrase}
-                  candidates={candidates}
-                />
-              )}
-            </>
-          )}
+                  candidateCount={totalCandidates}
+                >
+                  <WithdrawalCredentials
+                    onShowRisk={showRiskMessage}
+                    hasAcceptedRisk={hasAcceptedRisk}
+                    isActive={step === 3}
+                    candidates={candidates}
+                    onValidatorChange={setNewValidators}
+                    onBackStep={decrementStep}
+                    onNextStep={incrementStep}
+                    onUpdateSharedCredentials={updateSharedCredentials}
+                    onUpdateSharedSuggestedFee={updateSharedSuggestedFee}
+                    sharedCredentials={sharedWithdrawalCredentials}
+                    sharedSuggestedFeeRecipient={sharedSuggestedFee}
+                  />
+                </CreateValidatorStep>
+
+                <CreateValidatorStep
+                  requiredStake={requiredStake}
+                  rewardEstimate={calculatedRewards}
+                  candidateCount={totalCandidates}
+                >
+                  <KeystoreAuthentication
+                    onUpdateCandidates={setNewValidators}
+                    sharedKeystorePassword={sharedKeystorePassword}
+                    setSharedKeystorePassword={setKeystorePassword}
+                    candidates={candidates}
+                    onBackStep={decrementStep}
+                    onNextStep={incrementStep}
+                  />
+                </CreateValidatorStep>
+
+                {Boolean(candidates.length) && beaconSpec && (
+                  <SignDeposit
+                    sharedKeystorePassword={sharedKeystorePassword}
+                    beaconSpec={beaconSpec}
+                    sharedWithdrawalCredentials={sharedWithdrawalCredentials}
+                    sharedSuggestedFee={sharedSuggestedFee}
+                    onComplete={viewManagement}
+                    rewardEstimate={calculatedRewards}
+                    mnemonic={keyPhrase}
+                    candidates={candidates}
+                  />
+                )}
+              </>
+            ) as any
+          }
         </HorizontalStepper>
       ) : (
         <div className='w-full h-full flex items-center justify-center'>

--- a/src/components/ValidatorManagement/CreateValidatorView/StepOptions.tsx
+++ b/src/components/ValidatorManagement/CreateValidatorView/StepOptions.tsx
@@ -19,7 +19,12 @@ const StepOptions: FC<StepOptionsProps> = ({ onBackStep, onNextStep, isDisabledN
         </Button>
       )}
       {onNextStep && (
-        <Button isDisabled={isDisabledNext} type={ButtonFace.SECONDARY} onClick={onNextStep}>
+        <Button
+          dataTestId='next-btn'
+          isDisabled={isDisabledNext}
+          type={ButtonFace.SECONDARY}
+          onClick={onNextStep}
+        >
           {t('next')}
         </Button>
       )}

--- a/src/components/ValidatorManagement/CreateValidatorView/Steps/SignDepositValidators/MultiDeposits.tsx
+++ b/src/components/ValidatorManagement/CreateValidatorView/Steps/SignDepositValidators/MultiDeposits.tsx
@@ -14,6 +14,7 @@ export interface MultiDepositsProps {
   candidates: ValidatorCandidate[]
   sharedKeystorePassword: string | undefined
   sharedWithdrawalCredentials: string | undefined
+  sharedSuggestedFee: string | undefined
   beaconSpec: BeaconNodeSpecResults
   mnemonic: string
 }
@@ -23,6 +24,7 @@ const MultiDeposits: FC<MultiDepositsProps> = ({
   mnemonic,
   sharedWithdrawalCredentials,
   sharedKeystorePassword,
+  sharedSuggestedFee,
   beaconSpec,
 }) => {
   const { t } = useTranslation()
@@ -36,10 +38,11 @@ const MultiDeposits: FC<MultiDepositsProps> = ({
     keyStorePassword: string,
     pubKey: string,
     mnemonicIndex: number,
+    suggestedFeeRecipient: string,
   ) => {
     setDepositData((prev) => [
       ...prev,
-      { txHash, pubKey, keyStorePassword, mnemonicIndex, status: 'pending' },
+      { txHash, pubKey, keyStorePassword, mnemonicIndex, suggestedFeeRecipient, status: 'pending' },
     ])
   }
 
@@ -98,6 +101,7 @@ const MultiDeposits: FC<MultiDepositsProps> = ({
                       keyStorePassword: sharedKeystorePassword || validator.keyStorePassword,
                       withdrawalCredentials:
                         sharedWithdrawalCredentials || validator.withdrawalCredentials,
+                      suggestedFeeRecipient: sharedSuggestedFee || validator.suggestedFeeRecipient,
                     }}
                   />
                 ))}

--- a/src/components/ValidatorManagement/CreateValidatorView/Steps/SignDepositValidators/SignDeposit.tsx
+++ b/src/components/ValidatorManagement/CreateValidatorView/Steps/SignDepositValidators/SignDeposit.tsx
@@ -11,12 +11,14 @@ const SignDeposit: FC<SignDepositProps> = ({
   rewardEstimate,
   onComplete,
   sharedWithdrawalCredentials,
+  sharedSuggestedFee,
   sharedKeystorePassword,
   ...props
 }) => {
   return candidates.length > 1 ? (
     <MultiDeposits
       sharedWithdrawalCredentials={sharedWithdrawalCredentials}
+      sharedSuggestedFee={sharedSuggestedFee}
       sharedKeystorePassword={sharedKeystorePassword}
       candidates={candidates}
       {...props}

--- a/src/components/ValidatorManagement/CreateValidatorView/Steps/SignDepositValidators/SingleDeposit/SingleDeposit.tsx
+++ b/src/components/ValidatorManagement/CreateValidatorView/Steps/SignDepositValidators/SingleDeposit/SingleDeposit.tsx
@@ -32,7 +32,14 @@ const SingleDeposit: FC<SingleDepositProps> = ({
   ...props
 }) => {
   const { t } = useTranslation()
-  const { name, withdrawalCredentials, index, effectiveBalance, keyStorePassword } = candidate
+  const {
+    name,
+    withdrawalCredentials,
+    suggestedFeeRecipient,
+    index,
+    effectiveBalance,
+    keyStorePassword,
+  } = candidate
   const { DEPOSIT_NETWORK_ID } = beaconSpec
 
   const [step, setStep] = useState(0)
@@ -66,13 +73,21 @@ const SingleDeposit: FC<SingleDepositProps> = ({
   }, [txHash])
 
   useEffect(() => {
-    if (txStatus !== 'success' || !mnemonic || index === undefined || !keyStorePassword) return
+    if (
+      txStatus !== 'success' ||
+      !mnemonic ||
+      index === undefined ||
+      !keyStorePassword ||
+      !suggestedFeeRecipient
+    )
+      return
     ;(async () => {
       incrementStep()
       await importValidator({
         mnemonic,
         index,
         keyStorePassword,
+        suggestedFeeRecipient,
         onSuccess: () => {
           setIsSuccessScreen(true)
         },

--- a/src/components/ValidatorManagement/CreateValidatorView/Steps/ValidatorSetup/ValidatorSetup.tsx
+++ b/src/components/ValidatorManagement/CreateValidatorView/Steps/ValidatorSetup/ValidatorSetup.tsx
@@ -31,7 +31,8 @@ const ValidatorSetup: FC<ValidatorSetupProps> = ({
     index: undefined,
     keyStorePassword: undefined,
     name: undefined,
-    withdrawalCredentials: undefined,
+    withdrawalCredentials: '',
+    suggestedFeeRecipient: '',
   }
 
   const isValidBalances = candidates.every(

--- a/src/components/ValidatorManagement/CreateValidatorView/Steps/WithdrawalCredentials.tsx
+++ b/src/components/ValidatorManagement/CreateValidatorView/Steps/WithdrawalCredentials.tsx
@@ -1,6 +1,7 @@
+import clsx from 'clsx'
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import addClassString from '../../../../../utilities/addClassString'
+import { WithdrawalCredentialView } from '../../../../constants/enums'
 import { ValidatorCandidate } from '../../../../types'
 import CheckBox from '../../../CheckBox/CheckBox'
 import InfoBox, { InfoBoxType } from '../../../InfoBox/InfoBox'
@@ -16,8 +17,10 @@ export interface WithdrawalCredentialsProps {
   isActive: boolean
   hasAcceptedRisk: boolean
   onShowRisk: () => void
-  sharedCredentials?: string | undefined
+  sharedCredentials: string | undefined
+  sharedSuggestedFeeRecipient: string | undefined
   onUpdateSharedCredentials: (credentials?: string) => void
+  onUpdateSharedSuggestedFee: (suggestedFee?: string) => void
 }
 
 const WithdrawalCredentials: FC<WithdrawalCredentialsProps> = ({
@@ -29,12 +32,18 @@ const WithdrawalCredentials: FC<WithdrawalCredentialsProps> = ({
   onShowRisk,
   hasAcceptedRisk,
   sharedCredentials,
+  sharedSuggestedFeeRecipient,
   onUpdateSharedCredentials,
+  onUpdateSharedSuggestedFee,
 }) => {
   const { t } = useTranslation()
   const valCount = candidates.length
   const [isAll, setIsAll] = useState(false)
+  const [view, setView] = useState<WithdrawalCredentialView>(WithdrawalCredentialView.BASIC)
   const [isSharedCredentialVerified, setIsSharedCredentialVerified] = useState(false)
+  const [isSharedSuggestedFeeVerified, setIsSharedSuggestedFeeVerified] = useState(false)
+  const isAdvanceView = view === WithdrawalCredentialView.ADVANCED
+  const isBasicView = view === WithdrawalCredentialView.BASIC
 
   useEffect(() => {
     setIsAll(valCount > 1)
@@ -48,17 +57,31 @@ const WithdrawalCredentials: FC<WithdrawalCredentialsProps> = ({
 
   const isValidAddress = isAll
     ? Boolean(sharedCredentials)
-    : candidates.every(({ withdrawalCredentials }) => Boolean(withdrawalCredentials))
+    : candidates.every(({ withdrawalCredentials, suggestedFeeRecipient }) =>
+        Boolean(withdrawalCredentials && suggestedFeeRecipient),
+      )
   const isVerifiedAddress = isAll
-    ? isSharedCredentialVerified
-    : candidates.every(({ isVerifiedCredentials }) => isVerifiedCredentials)
+    ? isSharedCredentialVerified && isSharedSuggestedFeeVerified
+    : candidates.every(({ isVerifiedCredentials, isVerifiedSuggestedFee }) =>
+        Boolean(isVerifiedCredentials && isVerifiedSuggestedFee),
+      )
 
-  const updateSharedCandidateData = useCallback((_id: string, candidate: ValidatorCandidate) => {
-    const { withdrawalCredentials, isVerifiedCredentials } = candidate
+  const updateSharedCandidateData = useCallback(
+    (_id: string, candidate: ValidatorCandidate) => {
+      const {
+        withdrawalCredentials,
+        isVerifiedCredentials,
+        suggestedFeeRecipient,
+        isVerifiedSuggestedFee,
+      } = candidate
 
-    setIsSharedCredentialVerified(Boolean(isVerifiedCredentials))
-    onUpdateSharedCredentials(withdrawalCredentials)
-  }, [])
+      setIsSharedCredentialVerified(Boolean(isVerifiedCredentials))
+      setIsSharedSuggestedFeeVerified(Boolean(isVerifiedSuggestedFee))
+      onUpdateSharedCredentials(withdrawalCredentials)
+      onUpdateSharedSuggestedFee(suggestedFeeRecipient)
+    },
+    [onUpdateSharedSuggestedFee, onUpdateSharedCredentials],
+  )
 
   const updateCandidate = useCallback(
     (id: string, candidate: ValidatorCandidate) => {
@@ -72,23 +95,25 @@ const WithdrawalCredentials: FC<WithdrawalCredentialsProps> = ({
     [candidates, onValidatorChange],
   )
 
-  const toggleAssignAllCredentials = useCallback((): void => {
-    onUpdateSharedCredentials(undefined)
+  const clearCredentials = () => {
+    onUpdateSharedCredentials('')
+    onUpdateSharedSuggestedFee('')
     const updatedCandidates = candidates.map((validator) => ({
       ...validator,
       withdrawalCredentials: '',
+      suggestedFeeRecipient: '',
       isVerifiedCredentials: false,
+      isVerifiedSuggestedFee: false,
     }))
     onValidatorChange(updatedCandidates)
-    setIsAll((prev) => !prev)
     setIsSharedCredentialVerified(false)
-  }, [
-    onUpdateSharedCredentials,
-    candidates,
-    onValidatorChange,
-    setIsAll,
-    setIsSharedCredentialVerified,
-  ])
+    setIsSharedSuggestedFeeVerified(false)
+  }
+
+  const toggleAssignAllCredentials = useCallback((): void => {
+    clearCredentials()
+    setIsAll((prev) => !prev)
+  }, [setIsAll, clearCredentials])
 
   const moveToNextStep = (): void => {
     if (!isVerifiedAddress) {
@@ -98,9 +123,16 @@ const WithdrawalCredentials: FC<WithdrawalCredentialsProps> = ({
     onNextStep()
   }
 
-  const checkBoxClass = addClassString('flex space-x-4', [
-    valCount < 2 && 'opacity-0 pointer-events-none',
-  ])
+  const checkBoxClass = clsx('flex space-x-4', valCount < 2 && 'opacity-0 pointer-events-none')
+
+  const advanceTabClass = clsx(
+    'p-4 border-style border-b-0 cursor-pointer',
+    isAdvanceView ? 'opacity-100' : 'opacity-40',
+  )
+  const basicTabClass = clsx(
+    'p-4 border-style border-b-0 cursor-pointer border-r-0',
+    isBasicView ? 'opacity-100' : 'opacity-40',
+  )
 
   const allValidatorPlaceholder = useMemo(
     () =>
@@ -108,9 +140,18 @@ const WithdrawalCredentials: FC<WithdrawalCredentialsProps> = ({
         id: 'all',
         name: t('validatorManagement.withdrawalCredentials.validatorGroup'),
         withdrawalCredentials: sharedCredentials,
-        isVerifiedCredentials: isVerifiedAddress,
+        suggestedFeeRecipient: sharedSuggestedFeeRecipient,
+        isVerifiedCredentials: isSharedCredentialVerified,
+        isVerifiedSuggestedFee: isSharedSuggestedFeeVerified,
       }) as ValidatorCandidate,
-    [sharedCredentials, isVerifiedAddress, t],
+    [
+      sharedCredentials,
+      sharedSuggestedFeeRecipient,
+      isSharedCredentialVerified,
+      isSharedSuggestedFeeVerified,
+      t,
+      isBasicView,
+    ],
   )
 
   const renderedCredentialRows = useMemo(
@@ -118,12 +159,38 @@ const WithdrawalCredentials: FC<WithdrawalCredentialsProps> = ({
       candidates.map((validator, index) => (
         <ValidatorCredentialRow
           key={index}
+          isAdvanceView={isAdvanceView}
           validatorCandidate={validator}
           onUpdateCandidate={updateCandidate}
         />
       )),
     [candidates, updateCandidate],
   )
+
+  const renderedAllValidatorRow = useMemo(
+    () => (
+      <ValidatorCredentialRow
+        isAdvanceView={isAdvanceView}
+        validatorCandidate={allValidatorPlaceholder}
+        onUpdateCandidate={updateSharedCandidateData}
+      />
+    ),
+    [isAdvanceView, allValidatorPlaceholder, updateSharedCandidateData],
+  )
+
+  const changeView = (view: WithdrawalCredentialView) => {
+    setView(view)
+    clearCredentials()
+  }
+
+  const setAdvancedView = () => {
+    if (view === WithdrawalCredentialView.ADVANCED) return
+    changeView(WithdrawalCredentialView.ADVANCED)
+  }
+  const setBasicView = () => {
+    if (view === WithdrawalCredentialView.BASIC) return
+    changeView(WithdrawalCredentialView.BASIC)
+  }
 
   return (
     <div className='w-full h-full relative space-y-6'>
@@ -145,6 +212,14 @@ const WithdrawalCredentials: FC<WithdrawalCredentialsProps> = ({
           />
         </div>
         <div className='w-full'>
+          <div className='w-full flex'>
+            <div onClick={setBasicView} className={basicTabClass}>
+              <Typography type='text-caption1.5'>Basic Settings</Typography>
+            </div>
+            <div onClick={setAdvancedView} className={advanceTabClass}>
+              <Typography type='text-caption1.5'>Advanced Settings</Typography>
+            </div>
+          </div>
           <div className='w-full border-style px-4 py-2 flex space-x-2'>
             <div className='w-[250px] border-r border-r-style pr-2'>
               <Typography type='text-caption1'>{t('validatorManagement.validators')}</Typography>
@@ -166,14 +241,7 @@ const WithdrawalCredentials: FC<WithdrawalCredentialsProps> = ({
             </div>
           </div>
           <div className='overflow-scroll w-full max-h-[200px]'>
-            {isAll ? (
-              <ValidatorCredentialRow
-                validatorCandidate={allValidatorPlaceholder}
-                onUpdateCandidate={updateSharedCandidateData}
-              />
-            ) : (
-              renderedCredentialRows
-            )}
+            {isAll ? renderedAllValidatorRow : renderedCredentialRows}
           </div>
         </div>
         <StepOptions

--- a/src/constants/enums.ts
+++ b/src/constants/enums.ts
@@ -69,3 +69,8 @@ export enum WalletPrefix {
   ONE = 0x01,
   TWO = 0x02,
 }
+
+export enum WithdrawalCredentialView {
+  BASIC = 'BASIC',
+  ADVANCED = 'ADVANCED',
+}

--- a/src/hooks/__tests__/useChainSafeKeyStore.spec.ts
+++ b/src/hooks/__tests__/useChainSafeKeyStore.spec.ts
@@ -1,0 +1,105 @@
+import { create, IKeystore } from '@chainsafe/bls-keystore'
+import { renderHook, act } from '@testing-library/react-hooks'
+import { useRecoilValue } from 'recoil'
+import { blsModuleAtom } from '../../recoil/atoms'
+import useChainSafeKeygen from '../useChainSafeKeygen'
+import useChainSafeKeyStore, { KeyStoreData } from '../useChainSafeKeyStore'
+
+jest.mock('@chainsafe/bls-keystore', () => ({
+  create: jest.fn(),
+}))
+jest.mock('recoil', () => ({
+  useRecoilValue: jest.fn(),
+}))
+jest.mock('../useChainSafeKeygen')
+
+const mockCreate = create as jest.MockedFunction<typeof create>
+const mockUseRecoilValue = useRecoilValue as jest.MockedFunction<typeof useRecoilValue>
+const mockUseChainSafeKeygen = useChainSafeKeygen as jest.Mock
+
+describe('useChainSafeKeyStore', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('generates a keystore and returns KeyStoreData', async () => {
+    // Mock recoil to return a dummy module
+    mockUseRecoilValue.mockReturnValue({})
+
+    // Mock key derivation functions
+    const eipKey = 'derived-eip-key'
+    const secretBytes = new Uint8Array([1, 2, 3])
+    const publicBytes = new Uint8Array([4, 5, 6])
+    const mockDeriveEIP = jest.fn().mockReturnValue(eipKey)
+    const mockDeriveValidator = jest.fn().mockReturnValue({
+      secretKey: { toBytes: () => secretBytes },
+      publicKey: { toBytes: () => publicBytes },
+    })
+    mockUseChainSafeKeygen.mockReturnValue({
+      deriveEIP2334SubKey: mockDeriveEIP,
+      deriveValidatorSigningKey: mockDeriveValidator,
+    })
+
+    // Mock create() to resolve a dummy keystore with all required IKeystore fields
+    const dummyKeystore: IKeystore = {
+      version: 4,
+      uuid: 'dummy-uuid',
+      path: '',
+      pubkey: Buffer.from(publicBytes).toString('hex'),
+      crypto: {
+        kdf: {} as any,
+        checksum: {} as any,
+        cipher: {} as any,
+      },
+    }
+    mockCreate.mockResolvedValueOnce(dummyKeystore)
+
+    const { result } = renderHook(() => useChainSafeKeyStore())
+
+    let output: KeyStoreData | undefined
+    await act(async () => {
+      output = await result.current.generateKeystore(
+        'test-mnemonic',
+        1,
+        'test-password',
+        '0xFeeRecipient',
+      )
+    })
+
+    // Assertions
+    expect(mockUseRecoilValue).toHaveBeenCalledWith(blsModuleAtom)
+    expect(mockDeriveEIP).toHaveBeenCalledWith('test-mnemonic')
+    expect(mockDeriveValidator).toHaveBeenCalledWith(eipKey, 1)
+    expect(mockCreate).toHaveBeenCalledWith(
+      'test-password',
+      secretBytes,
+      publicBytes,
+      `m/12381/3600/1/0/0`,
+    )
+    expect(output).toEqual({
+      enable: true,
+      password: 'test-password',
+      keystore: dummyKeystore,
+      suggested_fee_recipient: '0xFeeRecipient',
+    })
+  })
+
+  it('throws an error if create() fails', async () => {
+    mockUseRecoilValue.mockReturnValue({})
+    mockUseChainSafeKeygen.mockReturnValue({
+      deriveEIP2334SubKey: () => 'eip',
+      deriveValidatorSigningKey: () => ({
+        secretKey: { toBytes: () => new Uint8Array() },
+        publicKey: { toBytes: () => new Uint8Array() },
+      }),
+    })
+    const error = new Error('keystore failure')
+    mockCreate.mockRejectedValueOnce(error)
+
+    const { result } = renderHook(() => useChainSafeKeyStore())
+
+    await expect(result.current.generateKeystore('mnemonic', 0, 'pwd', 'fee')).rejects.toThrow(
+      'keystore failure',
+    )
+  })
+})

--- a/src/hooks/__tests__/useImportValidator.spec.ts
+++ b/src/hooks/__tests__/useImportValidator.spec.ts
@@ -1,0 +1,94 @@
+import { renderHook, act } from '@testing-library/react-hooks'
+import axios from 'axios'
+import displayToast from '../../../utilities/displayToast'
+import { ToastType } from '../../types'
+import useChainSafeKeyStore from '../useChainSafeKeyStore'
+import useImportValidator, { ImportValidatorParams } from '../useImportValidator'
+
+jest.mock('axios')
+jest.mock('../../../utilities/displayToast')
+jest.mock('../useChainSafeKeyStore')
+
+const mockGenerateKeystore = jest.fn()
+;(useChainSafeKeyStore as jest.Mock).mockReturnValue({
+  generateKeystore: mockGenerateKeystore,
+})
+
+const mockedAxios = axios as jest.Mocked<typeof axios>
+const mockedDisplayToast = displayToast as jest.MockedFunction<typeof displayToast>
+
+describe('useImportValidator hook', () => {
+  const validParams: ImportValidatorParams = {
+    mnemonic: 'test mnemonic',
+    index: 1,
+    keyStorePassword: 'password',
+    suggestedFeeRecipient: '0xFeeRecipient',
+    onSuccess: jest.fn(),
+    onError: jest.fn(),
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should successfully import and call onSuccess', async () => {
+    const fakeKeystore = { data: 'keystore' }
+    mockGenerateKeystore.mockResolvedValueOnce(fakeKeystore)
+    mockedAxios.post.mockResolvedValueOnce({ status: 200 })
+
+    const { result, waitForNextUpdate } = renderHook(() => useImportValidator())
+
+    act(() => {
+      result.current.importValidator(validParams)
+    })
+
+    // Wait for hook state updates
+    await waitForNextUpdate()
+
+    expect(mockGenerateKeystore).toHaveBeenCalledWith(
+      validParams.mnemonic,
+      validParams.index,
+      validParams.keyStorePassword,
+      validParams.suggestedFeeRecipient,
+    )
+    expect(mockedAxios.post).toHaveBeenCalledWith('/api/validator-import', { data: fakeKeystore })
+    expect(result.current.isSuccess).toBe(true)
+    expect(result.current.isError).toBe(false)
+    expect(validParams.onSuccess).toHaveBeenCalled()
+  })
+
+  it('should handle errors and call onError', async () => {
+    mockGenerateKeystore.mockRejectedValueOnce(new Error('gen error'))
+
+    const { result, waitForNextUpdate } = renderHook(() => useImportValidator())
+
+    act(() => {
+      result.current.importValidator(validParams)
+    })
+
+    await waitForNextUpdate()
+
+    expect(result.current.isSuccess).toBe(false)
+    expect(result.current.isError).toBe(true)
+    expect(validParams.onError).toHaveBeenCalled()
+    expect(mockedDisplayToast).toHaveBeenCalledWith(expect.any(String), ToastType.ERROR)
+  })
+
+  it('should validate missing index and trigger error', async () => {
+    const params = { ...validParams, index: undefined as any }
+    const { result } = renderHook(() => useImportValidator())
+
+    // Wrap the call in an async act so that all the setState calls flush before assertions
+    await act(async () => {
+      await result.current.importValidator(params)
+    })
+
+    expect(result.current.isSuccess).toBe(false)
+    expect(result.current.isError).toBe(true)
+    expect(validParams.onError).toHaveBeenCalled()
+    expect(mockedDisplayToast).toHaveBeenCalledWith(
+      expect.stringMatching(/error.unexpectedValidatorImportError/),
+      ToastType.ERROR,
+    )
+  })
+})

--- a/src/hooks/useChainSafeKeyStore.ts
+++ b/src/hooks/useChainSafeKeyStore.ts
@@ -7,6 +7,7 @@ export interface KeyStoreData {
   enable: boolean
   password: string
   keystore: IKeystore
+  suggested_fee_recipient: string
 }
 
 export type useChainSafeKeyStoreReturnType = {
@@ -14,6 +15,7 @@ export type useChainSafeKeyStoreReturnType = {
     mnemonic: string,
     index: number,
     keyStorePassword: string,
+    suggestedFeeRecipient: string,
     keyDerivationPath?: string,
   ) => Promise<KeyStoreData>
 }
@@ -26,6 +28,7 @@ const useChainSafeKeyStore = (): useChainSafeKeyStoreReturnType => {
     mnemonic: string,
     index: number,
     keyStorePassword: string,
+    suggestedFeeRecipient: string,
   ): Promise<KeyStoreData> => {
     try {
       const eip2334SubKey = deriveEIP2334SubKey(mnemonic)
@@ -41,6 +44,7 @@ const useChainSafeKeyStore = (): useChainSafeKeyStoreReturnType => {
         enable: true,
         password: keyStorePassword,
         keystore,
+        suggested_fee_recipient: suggestedFeeRecipient,
       }
     } catch (e) {
       console.error(e)

--- a/src/hooks/useImportValidator.ts
+++ b/src/hooks/useImportValidator.ts
@@ -9,6 +9,7 @@ export interface ImportValidatorParams {
   mnemonic: string
   index: number
   keyStorePassword: string
+  suggestedFeeRecipient: string
   onSuccess?: () => void
   onError?: () => void
 }
@@ -21,13 +22,20 @@ const useImportValidator = () => {
   const { generateKeystore } = useChainSafeKeyStore()
 
   const importValidator = useCallback(
-    async ({ mnemonic, index, keyStorePassword, onSuccess, onError }: ImportValidatorParams) => {
+    async ({
+      mnemonic,
+      index,
+      keyStorePassword,
+      suggestedFeeRecipient,
+      onSuccess,
+      onError,
+    }: ImportValidatorParams) => {
       setIsSuccess(false)
       setIsLoading(true)
       setIsError(false)
 
       try {
-        if (index === undefined || index === null) {
+        if (index === undefined || index === null || !Number.isInteger(index)) {
           throw new Error('No validator index provided.')
         }
         if (!mnemonic) {
@@ -37,7 +45,16 @@ const useImportValidator = () => {
           throw new Error('No keystore password provided.')
         }
 
-        const keyStore = await generateKeystore(mnemonic, index, keyStorePassword)
+        if (!suggestedFeeRecipient) {
+          throw new Error('No Suggested Fee Recipient provided')
+        }
+
+        const keyStore = await generateKeystore(
+          mnemonic,
+          index,
+          keyStorePassword,
+          suggestedFeeRecipient,
+        )
         const response = await axios.post('/api/validator-import', { data: keyStore })
 
         if (response.status === 200) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -172,9 +172,11 @@ export type ValidatorCandidate = {
   withdrawalPrefix: WalletPrefix
   effectiveBalance: bigint
   withdrawalCredentials: string | undefined
+  suggestedFeeRecipient: string | undefined
   keyStorePassword: string | undefined
   isValidIndex?: boolean
   isVerifiedCredentials?: boolean
+  isVerifiedSuggestedFee?: boolean
 }
 
 export type ValidatorRewardEstimate = {
@@ -215,6 +217,7 @@ export type DepositData = {
   keyStorePassword: string
   mnemonicIndex: number
   status: TxStatus
+  suggestedFeeRecipient: string
 }
 
 export enum TimeUnit {


### PR DESCRIPTION
https://github.com/sigp/siren/issues/344

Some validators may not have set suggestedFeeRecipient when starting their nodes. This may cause issue when importing validators with siren. To prevent this we will always add suggestedFeeRecipient to the import api, defaulting to the same address for withdrawals or allowing advance view for users to set a different address.