### PR TITLE
Default 443 for docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   siren:
     image: sigp/siren
     ports:
-      - '4443:443' # comment this line when using `SSL_ENABLED=false`
+      - '443:443' # comment this line when using `SSL_ENABLED=false`
     #      - "4080:80"  # uncomment this line when using `SSL_ENABLED=false`
     env_file:
       - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: sigp/siren
     ports:
       - '443:443' # comment this line when using `SSL_ENABLED=false`
-    #      - "4080:80"  # uncomment this line when using `SSL_ENABLED=false`
+    #      - "80:80"  # uncomment this line when using `SSL_ENABLED=false`
     env_file:
       - .env
 #    uncomment these 2 lines if you use docker on linux and want to use the special host `host.docker.internal` as your BN/VC address


### PR DESCRIPTION
I think docker compose should default to 443. I'll update docs accordingly. 

This will then align with what we are saying when running docker straight up. 