### PR TITLE
Fix: pre electra

### DIFF
--- a/backend/src/tasks/tasks.service.ts
+++ b/backend/src/tasks/tasks.service.ts
@@ -157,7 +157,7 @@ export class TasksService implements OnApplicationBootstrap {
 
     return config === Network.Mainnet.toLowerCase()
       ? MAINNET_PECTRA_FORK_VERSION
-      : CONFIG_NAME === Network.Hoodi.toLowerCase()
+      : config === Network.Hoodi.toLowerCase()
         ? HOODI_PECTRA_FORK_VERSION
         : process.env.NEXT_PUBLIC_TESTNET_PECTRA_FORK_VERSION;
   }

--- a/backend/src/validator/validator.service.ts
+++ b/backend/src/validator/validator.service.ts
@@ -288,10 +288,14 @@ export class ValidatorService {
   }
 
   async fetchPartialWithdrawals(): Promise<PartialWithdrawal[]> {
-    return await this.cacheManager.get('partialWithdrawals');
+    const withdrawals =
+      await this.cacheManager.get<PartialWithdrawal[]>('partialWithdrawals');
+    return withdrawals ?? [];
   }
 
   async fetchPendingDeposits(): Promise<PendingDeposit[]> {
-    return await this.cacheManager.get('pendingDeposits');
+    const deposits =
+      await this.cacheManager.get<PendingDeposit[]>('pendingDeposits');
+    return deposits ?? [];
   }
 }


### PR DESCRIPTION
If running Siren v3.0.0 pre electra some api points fail. This pr fixes it by returning default  empty arrays instead of failing.