### PR TITLE
Fix: firefox modals

### DIFF
--- a/src/components/DisclosureModal/DisclosureModal.tsx
+++ b/src/components/DisclosureModal/DisclosureModal.tsx
@@ -36,7 +36,7 @@ const DisclosureModal: FC<DisclosureModalProps> = ({
         maxWidth: isTablet ? '448px' : '949px',
       }}
     >
-      <div className='w-full h-full flex'>
+      <div className='w-full flex'>
         <div
           className='hidden lg:block flex-shrink-0 w-80 bg-dark100'
           style={{

--- a/src/components/RodalModal/RodalModal.tsx
+++ b/src/components/RodalModal/RodalModal.tsx
@@ -43,7 +43,6 @@ const RodalModal: FC<RodalModalProps> = ({
     height: 'max-content',
     overflow: 'scroll',
     zIndex: 999,
-    display: 'inline-table', // fix max-content height on safari browsers
   }
 
   const customStyles = {

--- a/src/components/ValidatorManagement/CreateValidatorView/MaxEbModal.tsx
+++ b/src/components/ValidatorManagement/CreateValidatorView/MaxEbModal.tsx
@@ -16,7 +16,7 @@ const MaxEbModal = () => {
 
   return (
     <RodalModal onClose={onClose} styles={{ maxWidth: '650px' }} isVisible={isOpen}>
-      <div className='w-full h-full flex flex-col p-6 space-y-6 items-center justify-center'>
+      <div className='w-full flex flex-col p-6 space-y-6 items-center justify-center'>
         <i className='bi-exclamation-circle text-6xl text-warning' />
         <Typography type='text-caption1' className='text-center'>
           {t('validatorManagement.maxEBModal.text')}

--- a/src/components/ValidatorModal/ValidatorModal.tsx
+++ b/src/components/ValidatorModal/ValidatorModal.tsx
@@ -138,7 +138,6 @@ const ValidatorModal: FC<ValidatorModalProps> = ({
         maxWidth: isTablet ? '99%' : isLargeScreen ? '1200px' : '900px',
         height: isTablet ? '540px' : '653px',
         zIndex: 998,
-        display: 'inline-block',
       }}
       onClose={closeModal}
     >

--- a/src/forms/AuthenticationForm.tsx
+++ b/src/forms/AuthenticationForm.tsx
@@ -40,7 +40,7 @@ const AuthenticationForm: FC<AuthFormProps> = ({ children, onSubmit, isVisible }
   }
 
   return (
-    <form className='w-full h-full' onSubmit={submitForm}>
+    <form className='w-full' onSubmit={submitForm}>
       {children &&
         children({
           control,

--- a/src/forms/EditValidatorForm.tsx
+++ b/src/forms/EditValidatorForm.tsx
@@ -62,7 +62,7 @@ const EditValidatorForm: FC<EditValidatorFormProps> = ({ children, validator }) 
   }
 
   return (
-    <form className='w-full h-full' onSubmit={onSubmit}>
+    <form className='w-full' onSubmit={onSubmit}>
       {children &&
         children({
           control,


### PR DESCRIPTION
Safari doesnt like full height in max content parent containers. removed this for all modals so they work cross browser