### PR TITLE
Fix: consolidation que calc

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@types/js-cookie": "^3.0.6",
     "@types/jsonwebtoken": "^9.0.6",
     "@types/moment-duration-format": "^2.2.6",
-    "@types/react": "19.1.2",
+    "@types/react": "19.1.3",
     "@uiw/react-textarea-code-editor": "^2.1.1",
     "autoprefixer": "^10.4.19",
     "axios": "^1.8.4",
@@ -90,7 +90,7 @@
     ]
   },
   "devDependencies": {
-    "@types/node": "22.15.3",
+    "@types/node": "22.15.14",
     "@typescript-eslint/eslint-plugin": "^7.1.0",
     "cross-spawn": "^7.0.6",
     "eslint": "8.57.0",

--- a/src/components/ConsolidateValidator/Consolidate.tsx
+++ b/src/components/ConsolidateValidator/Consolidate.tsx
@@ -1,11 +1,12 @@
 import axios from 'axios'
-import { FC, useMemo, useState } from 'react'
+import { FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAccount, useSendTransaction, UseEstimateGasParameters } from 'wagmi'
 import displayToast from '../../../utilities/displayToast'
 import formatWithdrawalAddress from '../../../utilities/formatWithdrawalAddress'
 import { CONSOLIDATION_CONTRACT } from '../../constants/constants'
 import useCalculateGas from '../../hooks/useCalculateGas'
+import useFeeGetter from '../../hooks/useFeeGetter'
 import useHasSufficientBalance from '../../hooks/useHasSufficientBalance'
 import { ActivityType, ConsolidationTx, ToastType, TxHash } from '../../types'
 import { ValidatorInfo } from '../../types/validator'
@@ -15,7 +16,6 @@ import WalletActionGuard from '../WalletActionGuard/WalletActionGuard'
 export interface ConsolidateViewProps {
   targetPubKey: string
   sourceValidator: ValidatorInfo
-  queueLength: bigint | TxHash
   chainId: number
   bufferPercentage: bigint
   onSubmitRequest: (request: ConsolidationTx) => void
@@ -25,7 +25,6 @@ const Consolidate: FC<ConsolidateViewProps> = ({
   targetPubKey,
   sourceValidator,
   chainId,
-  queueLength,
   bufferPercentage,
   onSubmitRequest,
 }) => {
@@ -35,27 +34,7 @@ const Consolidate: FC<ConsolidateViewProps> = ({
   const { address } = useAccount()
   const [isLoading, setIsLoading] = useState(false)
   const submitRequest = useSendTransaction()
-  const getRequiredFee = (numerator: bigint, percentage = 0n): bigint => {
-    // https://eips.ethereum.org/EIPS/eip-7251#fee-calculation
-    let i = 1n
-    let output = 0n
-    let numeratorAccum = 1n * 17n
-
-    while (numeratorAccum > 0n) {
-      output += numeratorAccum
-      numeratorAccum = (numeratorAccum * numerator) / (17n * i)
-      i += 1n
-    }
-
-    const baseFee = output / 17n
-
-    return (baseFee * (100n + BigInt(percentage)) + (100n - 1n)) / 100n
-  }
-  const requestFee = useMemo(() => {
-    if (!queueLength) return 0n
-
-    return getRequiredFee(BigInt(queueLength), bufferPercentage)
-  }, [queueLength, bufferPercentage])
+  const { requestFee } = useFeeGetter(CONSOLIDATION_CONTRACT, Boolean(address), bufferPercentage)
 
   const { estimatedGasLimit, totalRequiredFunds } = useCalculateGas({
     chainId,

--- a/src/components/ValidatorManagement/ConsolidateView/Steps/SubmitConsolidationStep/ConsolidationQueueStatus.tsx
+++ b/src/components/ValidatorManagement/ConsolidateView/Steps/SubmitConsolidationStep/ConsolidationQueueStatus.tsx
@@ -5,7 +5,7 @@ import { TxHash } from '../../../../../types'
 import InfoBox, { InfoBoxType } from '../../../../InfoBox/InfoBox'
 
 export interface ConsolidationQueueStatusProps {
-  queueLength?: bigint | TxHash
+  queueLength?: bigint
   className?: string
   isActive: boolean
 }

--- a/src/components/ValidatorManagement/ConsolidateView/Steps/SubmitConsolidationStep/ConsolidationRequest.tsx
+++ b/src/components/ValidatorManagement/ConsolidateView/Steps/SubmitConsolidationStep/ConsolidationRequest.tsx
@@ -1,7 +1,7 @@
 import { dataSlice, getAddress } from 'ethers'
 import React, { FC } from 'react'
 import addClassString from '../../../../../../utilities/addClassString'
-import { ConsolidationTx, TxHash } from '../../../../../types'
+import { ConsolidationTx } from '../../../../../types'
 import { ValidatorInfo } from '../../../../../types/validator'
 import Consolidate from '../../../../ConsolidateValidator/Consolidate'
 import Spinner from '../../../../Spinner/Spinner'
@@ -12,7 +12,6 @@ export interface ConsolidationRequestProps {
   validator: ValidatorInfo
   chainId: number
   targetPubKey: string
-  consolidationQueLength: bigint | TxHash
   feeBuffer: bigint
   onSubmitRequest: (request: ConsolidationTx) => void
   requestData: ConsolidationTx | undefined
@@ -22,7 +21,6 @@ const ConsolidationRequest: FC<ConsolidationRequestProps> = ({
   validator,
   targetPubKey,
   chainId,
-  consolidationQueLength,
   feeBuffer,
   onSubmitRequest,
   requestData,
@@ -61,7 +59,6 @@ const ConsolidationRequest: FC<ConsolidationRequestProps> = ({
           <Consolidate
             bufferPercentage={feeBuffer}
             sourceValidator={validator}
-            queueLength={consolidationQueLength}
             onSubmitRequest={onSubmitRequest}
             chainId={chainId}
             targetPubKey={targetPubKey}

--- a/src/components/ValidatorManagement/ConsolidateView/Steps/SubmitConsolidationStep/SubmitConsolidationStep.tsx
+++ b/src/components/ValidatorManagement/ConsolidateView/Steps/SubmitConsolidationStep/SubmitConsolidationStep.tsx
@@ -100,6 +100,7 @@ const SubmitConsolidationStep: FC<SubmitConsolidationStepProps> = ({
             )
           })
         : null,
+    [targetValidator, chainId, sourceValidators, consolidationRequests, feeBuffer],
   )
 
   const renderedTxStatuses = useMemo(() => {

--- a/src/components/ValidatorManagement/ConsolidateView/Steps/SubmitConsolidationStep/SubmitConsolidationStep.tsx
+++ b/src/components/ValidatorManagement/ConsolidateView/Steps/SubmitConsolidationStep/SubmitConsolidationStep.tsx
@@ -70,6 +70,8 @@ const SubmitConsolidationStep: FC<SubmitConsolidationStepProps> = ({
     chainId,
   })
 
+  const queueLength: bigint = BigInt(consolidationQueLength ?? '0')
+
   useEffect(() => {
     const interval = setInterval(() => {
       refetch()
@@ -126,11 +128,7 @@ const SubmitConsolidationStep: FC<SubmitConsolidationStepProps> = ({
         <Typography type='text-subtitle2'>
           {t('validatorManagement.consolidateView.signAndSubmit.title')}
         </Typography>
-        <ConsolidationQueueStatus
-          isActive={isActive}
-          className='mt-4'
-          queueLength={consolidationQueLength || 0n}
-        />
+        <ConsolidationQueueStatus isActive={isActive} className='mt-4' queueLength={queueLength} />
       </div>
       <div className='flex-1 order-2 lg:order-1 lg:max-w-2xl mr-0 lg:mr-8 xl:mr-0 flex flex-col'>
         <div className='hidden lg:block'>
@@ -140,7 +138,7 @@ const SubmitConsolidationStep: FC<SubmitConsolidationStepProps> = ({
           <ConsolidationQueueStatus
             isActive={isActive}
             className='mt-4'
-            queueLength={consolidationQueLength || 0n}
+            queueLength={queueLength}
           />
         </div>
         <div className='w-full mt-4 flex flex-col'>

--- a/src/components/ValidatorManagement/ConsolidateView/Steps/SubmitConsolidationStep/SubmitConsolidationStep.tsx
+++ b/src/components/ValidatorManagement/ConsolidateView/Steps/SubmitConsolidationStep/SubmitConsolidationStep.tsx
@@ -96,12 +96,10 @@ const SubmitConsolidationStep: FC<SubmitConsolidationStepProps> = ({
                 chainId={chainId}
                 targetPubKey={targetPubKey}
                 validator={validator}
-                consolidationQueLength={consolidationQueLength || 0n}
               />
             )
           })
         : null,
-    [targetValidator, chainId, sourceValidators, consolidationRequests, consolidationQueLength],
   )
 
   const renderedTxStatuses = useMemo(() => {

--- a/src/components/ValidatorModal/views/ValidatorWithdrawal/ValidatorWithdrawal.tsx
+++ b/src/components/ValidatorModal/views/ValidatorWithdrawal/ValidatorWithdrawal.tsx
@@ -3,7 +3,7 @@ import { formatEther, parseUnits } from 'ethers'
 import Link from 'next/link'
 import React, { ChangeEvent, FC, useContext, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useAccount, UseEstimateGasParameters, usePublicClient, useSendTransaction } from 'wagmi'
+import { useAccount, UseEstimateGasParameters, useSendTransaction } from 'wagmi'
 import displayToast from '../../../../../utilities/displayToast'
 import formatWithdrawalAddress from '../../../../../utilities/formatWithdrawalAddress'
 import getBeaconChaLink from '../../../../../utilities/getBeaconChaLink'
@@ -15,6 +15,7 @@ import {
 } from '../../../../constants/constants'
 import { ValidatorModalView } from '../../../../constants/enums'
 import useCalculateGas from '../../../../hooks/useCalculateGas'
+import useFeeGetter from '../../../../hooks/useFeeGetter'
 import useHasSufficientBalance from '../../../../hooks/useHasSufficientBalance'
 import useProcessEffectiveBalance from '../../../../hooks/useProcessEffectiveBalance'
 import useResolveTransactionOnce from '../../../../hooks/useResolveTransactionOnce'
@@ -78,9 +79,8 @@ const ValidatorWithdrawal: FC<ValidatorWithdrawalProps> = ({
     ? MAX_EFFECTIVE_BALANCE
     : EFFECTIVE_BALANCE
   const { address } = useAccount()
-  const publicClient = usePublicClient()
+  const { requestFee } = useFeeGetter(EXECUTION_WITHDRAWAL_CONTRACT, Boolean(address))
   const submitRequest = useSendTransaction()
-  const [requestFee, setRequestFee] = useState<bigint>(0n)
   const { txStatus } = useResolveTransactionOnce(txHash)
 
   useEffect(() => {
@@ -142,23 +142,6 @@ const ValidatorWithdrawal: FC<ValidatorWithdrawalProps> = ({
   const { isSufficient } = useHasSufficientBalance(totalRequiredFunds)
 
   const setMaxAmount = () => setWithdrawalAmount(maxWithdrawal > 0.000000001 ? maxWithdrawal : 0)
-
-  useEffect(() => {
-    async function fetchFee() {
-      try {
-        if (!publicClient) return
-        const feeHex = await publicClient.request({
-          method: 'eth_call',
-          params: [{ to: EXECUTION_WITHDRAWAL_CONTRACT, data: '0x' }, 'latest'],
-        })
-
-        setRequestFee(BigInt(feeHex))
-      } catch (error) {
-        console.error('Error fetching fee:', error)
-      }
-    }
-    void fetchFee()
-  }, [publicClient])
 
   const handleTxError = (e: any) => {
     const error = (e as Error).message

--- a/src/hooks/useFeeGetter.ts
+++ b/src/hooks/useFeeGetter.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
 import { usePublicClient } from 'wagmi'
+import { TxHash } from '../types'
 
-const useFeeGetter = (contractAddress: string, isReady: boolean, bufferAmount: bigint = 0n) => {
+const useFeeGetter = (contractAddress: TxHash, isReady: boolean, bufferAmount: bigint = 0n) => {
   const publicClient = usePublicClient()
   const [requestFee, setRequestFee] = useState<bigint>(0n)
 

--- a/src/hooks/useFeeGetter.ts
+++ b/src/hooks/useFeeGetter.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react'
+import { usePublicClient } from 'wagmi'
+
+const useFeeGetter = (contractAddress: string, isReady: boolean, bufferAmount: bigint = 0n) => {
+  const publicClient = usePublicClient()
+  const [requestFee, setRequestFee] = useState<bigint>(0n)
+
+  useEffect(() => {
+    async function fetchFee() {
+      try {
+        if (!publicClient || !isReady || !contractAddress) return
+
+        const feeHex = await publicClient.request({
+          method: 'eth_call',
+          params: [{ to: contractAddress, data: '0x' }, 'latest'],
+        })
+
+        const rawFee = BigInt(feeHex)
+        const pct = BigInt(bufferAmount)
+
+        const adjusted = (rawFee * (100n + pct) + (100n - 1n)) / 100n
+
+        setRequestFee(adjusted)
+      } catch (error) {
+        console.error('Error fetching fee:', error)
+      }
+    }
+    void fetchFee()
+  }, [publicClient, contractAddress, isReady, bufferAmount])
+
+  return {
+    requestFee,
+  }
+}
+
+export default useFeeGetter

--- a/yarn.lock
+++ b/yarn.lock
@@ -2360,10 +2360,10 @@
   dependencies:
     undici-types "~6.20.0"
 
-"@types/node@22.15.3":
-  version "22.15.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.15.3.tgz#b7fb9396a8ec5b5dfb1345d8ac2502060e9af68b"
-  integrity sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==
+"@types/node@22.15.14":
+  version "22.15.14"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.15.14.tgz#889fd356a04d003a6d5650ccc003ef4d712430d7"
+  integrity sha512-BL1eyu/XWsFGTtDWOYULQEs4KR0qdtYfCxYAUYRoB7JP7h9ETYLgQTww6kH8Sj2C0pFGgrpM0XKv6/kbIzYJ1g==
   dependencies:
     undici-types "~6.21.0"
 
@@ -2384,10 +2384,10 @@
   resolved "https://registry.yarnpkg.com/@types/prismjs/-/prismjs-1.26.5.tgz#72499abbb4c4ec9982446509d2f14fb8483869d6"
   integrity sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==
 
-"@types/react@19.1.2":
-  version "19.1.2"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.1.2.tgz#11df86f66f188f212c90ecb537327ec68bfd593f"
-  integrity sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==
+"@types/react@19.1.3":
+  version "19.1.3"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.1.3.tgz#c75a24b775a63280b02c66a55a3cfa04f4022cf7"
+  integrity sha512-dLWQ+Z0CkIvK1J8+wrDPwGxEYFA4RAyHoZPxHVGspYmFVnwGSNT24cGIhFJrtfRnWVuW8X7NO52gCXmhkVUWGQ==
   dependencies:
     csstype "^3.0.2"
 


### PR DESCRIPTION
Instead of manually calculating the consolidation request fee based on the queue length, directly fetch the fee from the consolidation contract as done in the withdrawal component.