### PR TITLE
Fix broken Lighthouse book link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and Validator Client.
 ## Documentation
 
 The [Lighthouse Book](https://lighthouse-book.sigmaprime.io) contains information for users and
-developers. Specifically the [Lighthouse UI](https://lighthouse-book.sigmaprime.io/lighthouse-ui.html) section of the book.
+developers. Specifically the [Lighthouse UI](https://lighthouse-book.sigmaprime.io/ui.html) section of the book.
 
 ## Building From Source
 


### PR DESCRIPTION
When searching for documentation I noticed that one of the links to the Lighthouse book was broken.
This PR updates it to the correct link.