### PR TITLE
fix: remove unneeded timeout when switching log types

### DIFF
--- a/app/dashboard/logs/Main.tsx
+++ b/app/dashboard/logs/Main.tsx
@@ -62,13 +62,11 @@ const Main: FC<MainProps> = ({
     if (selection === logType) return
 
     setLoading(true)
+    selectType(selection as LogType)
 
     setTimeout(() => {
       setLoading(false)
-      setTimeout(() => {
-        selectType(selection as LogType)
-      }, 500)
-    }, 500)
+    }, 250)
   }
 
   return (


### PR DESCRIPTION
fix blink of old data when switching between bn/vc logs