### PR TITLE
Remove eth1 sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ build-storybook.log
 .next
 next-env.d.ts
 dist
+
+CLAUDE.md

--- a/app/dashboard/Main.tsx
+++ b/app/dashboard/Main.tsx
@@ -122,9 +122,8 @@ const Main: FC<MainProps> = (props) => {
     networkError,
   })
 
-  const { beaconSync, executionSync } = syncData
+  const { beaconSync } = syncData
   const { isSyncing } = beaconSync
-  const { isReady } = executionSync
   const { connected } = peerData
   const { natOpen } = nodeHealth
   const warningCount = metrics.warningCount || 0
@@ -156,20 +155,6 @@ const Main: FC<MainProps> = (props) => {
       message: t('alertMessages.beaconNotSync'),
     })
   }, [t, isSyncing, storeAlert, removeAlert])
-
-  useEffect(() => {
-    if (isReady) {
-      removeAlert(ALERT_ID.VALIDATOR_SYNC)
-      return
-    }
-
-    storeAlert({
-      id: ALERT_ID.VALIDATOR_SYNC,
-      severity: StatusColor.WARNING,
-      subText: t('fair'),
-      message: t('alertMessages.ethClientNotSync'),
-    })
-  }, [t, isReady, storeAlert, removeAlert])
 
   useEffect(() => {
     if (connected <= 50) {

--- a/app/setup/node-sync/Main.tsx
+++ b/app/setup/node-sync/Main.tsx
@@ -4,7 +4,6 @@ import BeaconSyncCard from '../../../src/components/BeaconSyncCard/BeaconSyncCar
 import SyncDisclosure from '../../../src/components/Disclosures/SyncDisclosure'
 import Typography from '../../../src/components/Typography/Typography'
 import ValidatorSetupLayout from '../../../src/components/ValidatorSetupLayout/ValidatorSetupLayout'
-import ValidatorSyncCard from '../../../src/components/ValidatorSyncCard/ValidatorSyncCard'
 import useNetworkMonitor from '../../../src/hooks/useNetworkMonitor'
 import useSWRPolling from '../../../src/hooks/useSWRPolling'
 import { SetupProps } from '../../../src/types'
@@ -26,7 +25,7 @@ const Main: FC<MainProps> = ({ initSyncData, beaconSpec }) => {
     networkError,
   })
 
-  const { beaconSync, executionSync } = syncData
+  const { beaconSync } = syncData
 
   useEffect(() => {
     document.documentElement.classList.remove('dark')
@@ -45,7 +44,6 @@ const Main: FC<MainProps> = ({ initSyncData, beaconSpec }) => {
         mediaQuery='@1200:overflow-hidden @1200:py-0 @1200:px-0 @1024:flex items-center @1024:justify-center'
       >
         <div className='w-full flex flex-col space-y-2 lg:space-y-0 lg:flex-row lg:space-x-2'>
-          <ValidatorSyncCard data={executionSync} />
           <BeaconSyncCard data={beaconSync} />
         </div>
         <div className='w-full border border-dark100 mt-4 space-y-4 p-4'>

--- a/backend/src/beacon/beacon.service.ts
+++ b/backend/src/beacon/beacon.service.ts
@@ -72,25 +72,12 @@ export class BeaconService {
         'syncData',
         slotInterval,
         async () => {
-          const [beaconResponse, executionResponse] = await Promise.all([
-            this.utilsService.sendHttpRequest({
-              url: `${this.beaconUrl}/eth/v1/node/syncing`,
-            }),
-            this.utilsService.sendHttpRequest({
-              url: `${this.beaconUrl}/lighthouse/eth1/syncing`,
-            }),
-          ]);
+          const beaconResponse = await this.utilsService.sendHttpRequest({
+            url: `${this.beaconUrl}/eth/v1/node/syncing`,
+          });
 
           const { head_slot, sync_distance, is_syncing } =
             beaconResponse.data.data;
-          const {
-            head_block_number,
-            head_block_timestamp,
-            latest_cached_block_number,
-            latest_cached_block_timestamp,
-            voting_target_timestamp,
-            eth1_node_sync_status_percentage,
-          } = executionResponse.data.data;
 
           const headSlot = Number(head_slot);
           const currentEpoch = Math.floor(headSlot / Number(SLOTS_PER_EPOCH));
@@ -106,15 +93,6 @@ export class BeaconService {
               beaconSyncTime: Number(sync_distance) * (slotInterval / 1000),
               syncDistance: Number(sync_distance),
               isSyncing: is_syncing,
-            },
-            executionSync: {
-              headSlot: Number(head_block_number || 0),
-              headTimestamp: head_block_timestamp,
-              cachedHeadSlot: Number(latest_cached_block_number || 0),
-              cachedHeadTimestamp: latest_cached_block_timestamp,
-              votingTimestamp: voting_target_timestamp,
-              syncPercentage: Number(eth1_node_sync_status_percentage || 0),
-              isReady: eth1_node_sync_status_percentage === 100,
             },
           };
         },

--- a/backend/src/beacon/tests/beacon.controller.spec.ts
+++ b/backend/src/beacon/tests/beacon.controller.spec.ts
@@ -137,11 +137,6 @@ describe('BeaconController', () => {
       } as AxiosResponse;
       mockHttpService.request.mockReturnValueOnce(of(httpBeaconResponse));
 
-      const httpExecutionResponse: AxiosResponse = {
-        data: { data: mockedSyncNodeResults.execution },
-      } as AxiosResponse;
-      mockHttpService.request.mockReturnValueOnce(of(httpExecutionResponse));
-
       mockCacheManager.get.mockResolvedValueOnce({ SLOTS_PER_EPOCH: '32' });
       mockCacheManager.get.mockResolvedValueOnce({ SECONDS_PER_SLOT: '12' });
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   siren:
-    image: siren
+    image: sigp/siren
     ports:
       - '443:443' # comment this line when using `SSL_ENABLED=false`
     #      - "80:80"  # uncomment this line when using `SSL_ENABLED=false`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   siren:
-    image: sigp/siren
+    image: siren
     ports:
       - '443:443' # comment this line when using `SSL_ENABLED=false`
     #      - "80:80"  # uncomment this line when using `SSL_ENABLED=false`

--- a/src/components/DiagnosticTable/HardwareInfo.tsx
+++ b/src/components/DiagnosticTable/HardwareInfo.tsx
@@ -19,7 +19,6 @@ const HardwareInfo: FC<HardwareInfoProps> = ({ syncData, beanHealth }) => {
   const { t } = useTranslation()
   const {
     beaconSync: { beaconSyncTime, beaconPercentage, isSyncing },
-    executionSync: { syncPercentage, isReady },
   } = syncData
   const [view, setView] = useState<DiagnosticType>(DiagnosticType.DEVICE)
   const {
@@ -102,15 +101,6 @@ const HardwareInfo: FC<HardwareInfoProps> = ({ syncData, beanHealth }) => {
                   : t('networkUnavailable')
               }
               status={natOpen ? StatusColor.SUCCESS : StatusColor.DARK}
-            />
-            <DiagnosticCard
-              size={size}
-              maxHeight='flex-1'
-              title='Ethereum Mainnet'
-              metric=' '
-              percent={syncPercentage}
-              isBackground={false}
-              subTitle={t('connectedStatus', { status: isReady ? t('inSync') : t('outOfSync') })}
             />
             <DiagnosticCard
               size={size}

--- a/src/components/HealthCheck/NetworkHealth.tsx
+++ b/src/components/HealthCheck/NetworkHealth.tsx
@@ -16,7 +16,6 @@ export interface NetworkHealthProps {
 const NetworkHealth: FC<NetworkHealthProps> = ({ syncData, nodeHealth }) => {
   const {
     beaconSync: { beaconPercentage, beaconSyncTime },
-    executionSync: { isReady, syncPercentage },
   } = syncData
 
   const { t } = useTranslation()
@@ -46,14 +45,6 @@ const NetworkHealth: FC<NetworkHealthProps> = ({ syncData, nodeHealth }) => {
             : t('networkUnavailable')
         }
         status={natOpen ? StatusColor.SUCCESS : StatusColor.DARK}
-      />
-      <DiagnosticCard
-        size='health'
-        title='Ethereum Geth'
-        metric=' '
-        percent={syncPercentage}
-        isBackground={false}
-        subTitle={t('connectedStatus', { status: isReady ? t('inSync') : t('outOfSync') })}
       />
       <DiagnosticCard
         size='health'

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -12,7 +12,6 @@ import Button, { ButtonFace } from '../Button/Button'
 import Typography from '../Typography/Typography'
 import WalletProvider from '../Wallet/WalletProvider'
 import BeaconMetric from './BeaconMetric'
-import ValidatorMetric from './ValidatorMetric'
 
 export interface TopBarProps {
   syncData: SyncData
@@ -24,7 +23,7 @@ const TopBar: FC<TopBarProps> = ({ syncData, beaconSpec, initActivityData }) => 
   const { t } = useTranslation()
   const { DEPOSIT_NETWORK_ID } = beaconSpec
   const toggleSideBar = useSetRecoilState(isSideBarOpen)
-  const { beaconSync, executionSync } = syncData
+  const { beaconSync } = syncData
   const openSideBar = () => toggleSideBar(true)
 
   return (
@@ -40,7 +39,6 @@ const TopBar: FC<TopBarProps> = ({ syncData, beaconSpec, initActivityData }) => 
           <LightHouseFullLogo className='hidden w-full lg:flex text-black dark:text-white' />
         </div>
         <div className='hidden lg:flex h-full'>
-          <ValidatorMetric data={executionSync} />
           <BeaconMetric data={beaconSync} />
           <div className='hidden w-24 border-r border-borderLight dark:border-dark800 p-2'>
             <div className='flex-1 space-y-2'>

--- a/src/mocks/beacon.ts
+++ b/src/mocks/beacon.ts
@@ -22,15 +22,6 @@ export const mockedSyncResults = {
     slotDistance: 2,
     syncDistance: 1,
   },
-  executionSync: {
-    cachedHeadSlot: 1,
-    cachedHeadTimestamp: '1',
-    headSlot: 1,
-    headTimestamp: '1',
-    isReady: false,
-    syncPercentage: 1,
-    votingTimestamp: '1',
-  },
 }
 
 export const mockValCacheValues = [

--- a/src/types/beacon.ts
+++ b/src/types/beacon.ts
@@ -1,9 +1,8 @@
-import { BeaconSyncInfo, ValidatorSyncInfo } from './diagnostic'
+import { BeaconSyncInfo } from './diagnostic'
 import { NetworkId } from './index'
 
 export type SyncData = {
   beaconSync: BeaconSyncInfo
-  executionSync: ValidatorSyncInfo
 }
 
 export type BeaconNodeSpecResults = {


### PR DESCRIPTION
This removes Eth1 syncing as we can no longer get this information from the beacon chain. 

This should resolve: https://github.com/sigp/siren/issues/405