### PR TITLE
[WIP] Add commit hash display on Siren

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ FROM $node_image AS builder
 
 ENV NEXT_TELEMETRY_DISABLED=1 \
     NODE_ENV=development
+# Install git for commit hash generation for docker built image
+RUN apt-get update && apt-get install -y git && apt-get clean && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY . /app/
 

--- a/custom.d.ts
+++ b/custom.d.ts
@@ -20,6 +20,6 @@ declare module '@leodeslf/perlin-noise'
 
 declare namespace NodeJS {
   interface ProcessEnv {
-    COMMIT_HASH: string
+    NEXT_PUBLIC_COMMIT_HASH: string
   }
 }

--- a/custom.d.ts
+++ b/custom.d.ts
@@ -17,3 +17,9 @@ declare module 'i18next'
 declare module '@testing-library/react'
 
 declare module '@leodeslf/perlin-noise'
+
+declare namespace NodeJS {
+  interface ProcessEnv {
+    COMMIT_HASH: string
+  }
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,18 @@
 /** @type {import('next').NextConfig} */
+const { execSync } = require('child_process')
+
 const nextConfig = {
   reactStrictMode: false,
-  webpack(config, { dev }) {
+  env: {
+    COMMIT_HASH: (() => {
+      try {
+        return execSync('git rev-parse --short HEAD').toString().trim()
+      } catch (error) {
+        return 'unknown'
+      }
+    })(),
+  },
+  webpack(config) {
     config.module.rules.push({
       test: /\.svg$/,
       use: ['@svgr/webpack'],

--- a/next.config.js
+++ b/next.config.js
@@ -6,8 +6,16 @@ const nextConfig = {
   env: {
     NEXT_PUBLIC_COMMIT_HASH: (() => {
       try {
-        return execSync('git rev-parse --short HEAD').toString().trim()
+        console.log('Attempting to get git commit hash...')
+        console.log('Working directory:', process.cwd())
+        const result = execSync('git rev-parse --short HEAD', { 
+          cwd: process.cwd(),
+          encoding: 'utf8' 
+        }).trim()
+        console.log('Git command successful, hash:', result)
+        return result
       } catch (error) {
+        console.error('Git command failed:', error.message)
         return 'unknown'
       }
     })(),

--- a/next.config.js
+++ b/next.config.js
@@ -4,7 +4,7 @@ const { execSync } = require('child_process')
 const nextConfig = {
   reactStrictMode: false,
   env: {
-    COMMIT_HASH: (() => {
+    NEXT_PUBLIC_COMMIT_HASH: (() => {
       try {
         return execSync('git rev-parse --short HEAD').toString().trim()
       } catch (error) {

--- a/src/components/AppGreeting/AppGreeting.tsx
+++ b/src/components/AppGreeting/AppGreeting.tsx
@@ -18,6 +18,7 @@ const AppGreeting: FC<AppGreetingProps> = ({ sirenVersion, userName, ...props })
 
   useEffect(() => {
     setReady(true)
+    console.log('DEBUG - NEXT_PUBLIC_COMMIT_HASH:', process.env.NEXT_PUBLIC_COMMIT_HASH)
   }, [])
 
   return (

--- a/src/components/AppGreeting/AppGreeting.tsx
+++ b/src/components/AppGreeting/AppGreeting.tsx
@@ -37,7 +37,14 @@ const AppGreeting: FC<AppGreetingProps> = ({ sirenVersion, userName, ...props })
             <Typography type='text-tiny' family='font-roboto' darkMode='dark:text-white' isBold>
               {t('lighthouseUiVersion')}
             </Typography>
-            {sirenVersion && <PillIcon bgColor='bg-tertiary' text={`v${sirenVersion}`} />}
+            {sirenVersion && (
+              <div className='flex items-center space-x-2'>
+                <PillIcon bgColor='bg-tertiary' text={`v${sirenVersion}`} />
+                {process.env.NEXT_PUBLIC_COMMIT_HASH && (
+                  <PillIcon bgColor='bg-gray-500' text={process.env.COMMIT_HASH} />
+                )}
+              </div>
+            )}
           </div>
           <div>
             <Typography type='text-tiny' family='font-roboto' darkMode='dark:text-white' isBold>

--- a/src/components/AppGreeting/AppGreeting.tsx
+++ b/src/components/AppGreeting/AppGreeting.tsx
@@ -40,7 +40,7 @@ const AppGreeting: FC<AppGreetingProps> = ({ sirenVersion, userName, ...props })
             {sirenVersion && (
               <div className='flex items-center space-x-2'>
                 <PillIcon bgColor='bg-tertiary' text={`v${sirenVersion}`} />
-                {process.env.NEXT_PUBLIC_COMMIT_HASH && (
+                {process.env.COMMIT_HASH && (
                   <PillIcon bgColor='bg-gray-500' text={process.env.COMMIT_HASH} />
                 )}
               </div>

--- a/src/components/AppGreeting/AppGreeting.tsx
+++ b/src/components/AppGreeting/AppGreeting.tsx
@@ -40,8 +40,8 @@ const AppGreeting: FC<AppGreetingProps> = ({ sirenVersion, userName, ...props })
             {sirenVersion && (
               <div className='flex items-center space-x-2'>
                 <PillIcon bgColor='bg-tertiary' text={`v${sirenVersion}`} />
-                {process.env.COMMIT_HASH && (
-                  <PillIcon bgColor='bg-gray-500' text={process.env.COMMIT_HASH} />
+                {process.env.NEXT_PUBLIC_COMMIT_HASH && (
+                  <PillIcon bgColor='bg-gray-500' text={process.env.NEXT_PUBLIC_COMMIT_HASH} />
                 )}
               </div>
             )}


### PR DESCRIPTION
Resolves #393  

Work in progress now. Currently it is showing an `unknown` that is supposed to be the commit hash:

<img width="748" height="461" alt="Screenshot from 2025-08-25 09-57-08" src="https://github.com/user-attachments/assets/83b70557-b463-4ff0-995c-86c6885148b2" />
