### PR TITLE
Change default port from 3000 to 3300

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ SESSION_PASSWORD=default-siren-password
 SSL_ENABLED=true
 DEBUG=false
 # don't change these when building the docker image, only change when running outside of docker
-PORT=3000
+PORT=3300
 BACKEND_URL=http://127.0.0.1:3001
 # if BACKEND_URL is changed, BACKEND_PORT must have a matching port
 BACKEND_PORT=3001

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Navigate to the backend directory `cd backend`. Install all required Node packag
 
 After initializing the backend, return to the root directory. Install all frontend dependencies by executing `yarn`. Build the frontend using `yarn build`. Start the frontend production server with `yarn start`.
 
-This will allow you to access siren at `http://localhost:3000` by default.
+This will allow you to access siren at `http://localhost:3300` by default.
 
 ## Running Local Testnet
 

--- a/docker-assets/docker-entrypoint.sh
+++ b/docker-assets/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 
 # configure default vars if none provided
 set -a
-PORT=${PORT:-3000}
+PORT=${PORT:-3300}
 BACKEND_URL=${BACKEND_URL:-http://127.0.0.1:3001}
 BEACON_URL=${BEACON_URL:-http://your-BN-ip:5052}
 VALIDATOR_URL=${VALIDATOR_URL:-http://your-VC-ip:5062}

--- a/docker-assets/siren-http.conf
+++ b/docker-assets/siren-http.conf
@@ -2,6 +2,6 @@ server {
     listen       80  default_server;
 
     location / {
-        proxy_pass http://localhost:3000;
+        proxy_pass http://localhost:3300;
     }
 }

--- a/docker-assets/siren-https.conf
+++ b/docker-assets/siren-https.conf
@@ -7,6 +7,6 @@ server {
     ssl_ciphers         HIGH:!aNULL:!MD5;
 
     location / {
-        proxy_pass http://localhost:3000;
+        proxy_pass http://localhost:3300;
     }
 }

--- a/siren.js
+++ b/siren.js
@@ -6,7 +6,7 @@ require('dotenv').config()
 const dev = process.env.NODE_ENV !== 'production'
 const app = next({ dev })
 const handle = app.getRequestHandler()
-const PORT = process.env.PORT || 3000
+const PORT = process.env.PORT || 3300
 
 const backendUrl = process.env.BACKEND_URL || 'http://127.0.0.1:3001'
 

--- a/src/constants/envars.ts
+++ b/src/constants/envars.ts
@@ -1,4 +1,4 @@
 export const BACKEND_URL = process.env.BACKEND_URL || 'http://127.0.0.1:3001'
 export const BACKEND_PORT = process.env.BACKEND_PORT || 3001
-export const PORT = process.env.PORT || 3000
+export const PORT = process.env.PORT || 3300
 export const NODE_ENV = process.env.NODE_ENV

--- a/utilities/__tests__/calculateEpochEstimate.spec.ts
+++ b/utilities/__tests__/calculateEpochEstimate.spec.ts
@@ -20,12 +20,12 @@ describe('calculateEpochEstimate util', () => {
     ).toBe(0)
   })
   it('should return correct values', () => {
-    mockedFormatUnits.mockReturnValue('3000')
+    mockedFormatUnits.mockReturnValue('3300')
     expect(
       calculateEpochEstimate(secondsInHour, 12, {
         2323: [32000000, 32000000],
         2324: [32000000, 32000000],
       }),
-    ).toBe(3000)
+    ).toBe(3300)
   })
 })

--- a/utilities/__tests__/formatEndpoint.spec.ts
+++ b/utilities/__tests__/formatEndpoint.spec.ts
@@ -3,12 +3,12 @@ import { Protocol } from '../../src/constants/enums'
 
 describe('format endpoint util', () => {
   it('should return the correct format', () => {
-    expect(formatEndpoint({ protocol: Protocol.HTTP, port: 3000, address: 'localhost' })).toBe(
-      'http://localhost:3000',
+    expect(formatEndpoint({ protocol: Protocol.HTTP, port: 3300, address: 'localhost' })).toBe(
+      'http://localhost:3300',
     )
     expect(
-      formatEndpoint({ protocol: Protocol.HTTP, port: 3000, address: 'localhost/beacon' }),
-    ).toBe('http://localhost:3000/beacon')
+      formatEndpoint({ protocol: Protocol.HTTP, port: 3300, address: 'localhost/beacon' }),
+    ).toBe('http://localhost:3300/beacon')
   })
   it('should return undefined if missing endpoint', () => {
     expect(formatEndpoint()).toBe(undefined)


### PR DESCRIPTION
I propose to change the default port from 3000 to 3300. This is because 3000 is the default port used by Grafana, so if a user is running Grafana, he would have to change the Siren port. If we change the default port in Siren away from 3000, then users don't have to do that.