### PR TITLE
Add kubernetes stuff to siren

### DIFF
--- a/kube/bin/create_secret.py
+++ b/kube/bin/create_secret.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""
+create_secret.py — Create or update a Kubernetes Secret from a file or stdin.
+
+Requirements:
+  pip install kubernetes
+
+Usage examples:
+  # From file; secret name defaults to sanitized file name; namespace from context
+  python create_secret.py -f secret.txt
+
+  # From stdin; secret name defaults to 3-letter month + day, e.g., aug11
+  echo -n "supersecret" | python create_secret.py
+
+  # Explicit secret name and namespace; overwrite if it exists
+  python create_secret.py -f cert.pem -s tls-cert -n myns --force
+"""
+import argparse
+import base64
+import datetime as dt
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Optional, Tuple
+
+from kubernetes import client, config
+from kubernetes.client.exceptions import ApiException
+
+
+def read_bytes_from_source(path: Optional[str]) -> bytes:
+    if path:
+        with open(path, "rb") as f:
+            return f.read()
+    return sys.stdin.buffer.read()
+
+
+def month_abbrev_day_today() -> str:
+    # e.g., 'aug11' (lowercase for DNS-1123)
+    today = dt.date.today()
+    return f"{today.strftime('%b').lower()}{today.strftime('%d')}"
+
+
+def strip_all_suffixes(p: Path) -> Path:
+    while p.suffix:
+        p = p.with_suffix("")
+    return p
+
+
+def sanitize_name(name: str) -> str:
+    """Make DNS-1123 compliant."""
+    name = name.lower()
+    name = re.sub(r"[^a-z0-9-]", "-", name)
+    name = re.sub(r"-{2,}", "-", name).strip("-")
+    if not name:
+        name = month_abbrev_day_today()
+    if len(name) > 253:
+        name = name[:253].rstrip("-")
+    name = re.sub(r"^[^a-z0-9]+", "", name)
+    name = re.sub(r"[^a-z0-9]+$", "", name)
+    if not name:
+        name = month_abbrev_day_today()
+    return name
+
+
+def default_name_from_file(file_path: str) -> str:
+    p = Path(file_path)
+    stem_all = strip_all_suffixes(p).name or p.stem or p.name
+    return sanitize_name(stem_all)
+
+
+def guess_default_namespace() -> str:
+    # 1) in-cluster SA namespace
+    sa_ns_file = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+    if os.path.exists(sa_ns_file):
+        try:
+            with open(sa_ns_file, "r", encoding="utf-8") as f:
+                ns = f.read().strip()
+                if ns:
+                    return ns
+        except Exception:
+            pass
+    # 2) kubeconfig context
+    try:
+        contexts, active = config.list_kube_config_contexts()
+        if active and "context" in active:
+            ctx = active["context"]
+            ns = ctx.get("namespace")
+            if ns:
+                return ns
+    except Exception:
+        pass
+    # 3) fallback
+    return "default"
+
+
+def load_kube_config() -> Tuple[bool, Optional[Exception]]:
+    try:
+        config.load_incluster_config()
+        return True, None
+    except Exception:
+        try:
+            config.load_kube_config()
+            return True, None
+        except Exception as e_out:
+            return False, e_out
+
+
+def ensure_secret(
+    api: client.CoreV1Api,
+    name: str,
+    namespace: str,
+    data_key: str,
+    raw_bytes: bytes,
+    secret_type: str,
+    force: bool,
+) -> None:
+    b64 = base64.b64encode(raw_bytes).decode("ascii")
+    metadata = client.V1ObjectMeta(name=name, namespace=namespace)
+    body = client.V1Secret(
+        api_version="v1",
+        kind="Secret",
+        metadata=metadata,
+        type=secret_type,
+        data={data_key: b64},
+    )
+
+    # Check existence
+    try:
+        existing = api.read_namespaced_secret(name=name, namespace=namespace)
+        exists = True
+    except ApiException as e:
+        if e.status == 404:
+            exists = False
+        else:
+            raise
+
+    if exists and not force:
+        print(
+            f"Secret '{name}' already exists in namespace '{namespace}'. Use --force to overwrite.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if exists and force:
+        body.metadata.resource_version = existing.metadata.resource_version
+        api.replace_namespaced_secret(name=name, namespace=namespace, body=body)
+        print(f"Replaced Secret '{name}' in namespace '{namespace}'.")
+    else:
+        api.create_namespaced_secret(namespace=namespace, body=body)
+        print(f"Created Secret '{name}' in namespace '{namespace}'.")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Create a Kubernetes Secret from a file or stdin."
+    )
+    p.add_argument(
+        "-f", "--file",
+        help="Path to file containing the secret bytes. If omitted, read from stdin.",
+    )
+    p.add_argument(
+        "-s", "--secretname",
+        help="Secret name. Defaults to sanitized file name; if reading from stdin, "
+             "defaults to today's 3-letter month + day (e.g., aug11).",
+    )
+    p.add_argument(
+        "-k", "--key",
+        default="password",
+        help="Key inside the Secret data map (default: 'password').",
+    )
+    p.add_argument(
+        "-n", "--namespace",
+        help='Namespace to create the Secret in. Defaults to the current context\'s namespace or "default".',
+    )
+    p.add_argument(
+        "--type",
+        default="Opaque",
+        help="Secret type (default: Opaque).",
+    )
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite the Secret if it already exists.",
+    )
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    # Determine secret name
+    if args.secretname:
+        name = sanitize_name(args.secretname)
+    elif args.file:
+        name = default_name_from_file(args.file)
+    else:
+        name = month_abbrev_day_today()  # e.g., 'aug11'
+
+    # Determine namespace
+    namespace = args.namespace or guess_default_namespace()
+
+    # Read content
+    payload = read_bytes_from_source(args.file)
+    if not payload:
+        print("Refusing to create an empty Secret (no input provided).", file=sys.stderr)
+        sys.exit(2)
+
+    # Kube client
+    loaded, err = load_kube_config()
+    if not loaded:
+        print(f"Failed to load Kubernetes config: {err!s}", file=sys.stderr)
+        sys.exit(3)
+    api = client.CoreV1Api()
+
+    # Create or replace
+    try:
+        ensure_secret(
+            api=api,
+            name=name,
+            namespace=namespace,
+            data_key=args.key,
+            raw_bytes=payload,
+            secret_type=args.type,
+            force=bool(args.force),
+        )
+    except ApiException as e:
+        msg = getattr(e, "reason", str(e))
+        status = getattr(e, "status", "unknown")
+        print(f"Kubernetes API error (status {status}): {msg}", file=sys.stderr)
+        if e.body:
+            print(e.body, file=sys.stderr)
+        sys.exit(4)
+
+
+if __name__ == "__main__":
+    main()

--- a/kube/bin/genpw.py
+++ b/kube/bin/genpw.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+pwgen.py – Generate a random password and (optionally) store it in a Kubernetes Secret.
+
+Examples
+--------
+# Just print a 12-character password
+python pwgen.py -l 12
+
+# Create Secret db-pw in the default context namespace
+python pwgen.py -l 16 -s db-pw
+
+# Same but in the staging namespace
+python pwgen.py -l 16 -n staging -s db-pw
+
+# Replace the Secret if it already exists
+python pwgen.py -l 20 -s db-pw --force
+"""
+
+import argparse
+import secrets
+import string
+from random import SystemRandom
+
+from kubernetes import client, config
+from kubernetes.client.rest import ApiException
+
+
+# ───────────────────────── Password generation ──────────────────────────
+def generate_password(length: int = 10) -> str:
+    if length < 3:
+        raise ValueError("Length must be at least 3 (lower, upper, digit).")
+
+    chars = [
+        secrets.choice(string.ascii_lowercase),
+        secrets.choice(string.ascii_uppercase),
+        secrets.choice(string.digits),
+    ]
+    alphabet = string.ascii_letters + string.digits
+    chars += [secrets.choice(alphabet) for _ in range(length - 3)]
+    SystemRandom().shuffle(chars)
+    return "".join(chars)
+
+
+# ───────────────────────── Kubernetes helpers ───────────────────────────
+def get_default_namespace() -> str:
+    """Return namespace from current kube-context, defaulting to 'default'."""
+    contexts, current = config.list_kube_config_contexts()
+    if not current:
+        return "default"
+    return current.get("context", {}).get("namespace", "default")
+
+
+def create_secret(namespace: str, name: str, password: str, force: bool) -> None:
+    v1 = client.CoreV1Api()
+    body = client.V1Secret(
+        metadata=client.V1ObjectMeta(name=name),
+        type="Opaque",
+        string_data={"password": password},
+    )
+
+    try:
+        v1.create_namespaced_secret(namespace, body)
+        print(f"✅ Secret '{name}' created in namespace '{namespace}'.")
+    except ApiException as e:
+        if e.status == 409:  # Already exists
+            if force:
+                v1.replace_namespaced_secret(name, namespace, body)
+                print(f"♻️  Secret '{name}' replaced in namespace '{namespace}'.")
+            else:
+                print(
+                    f"⚠️  Secret '{name}' already exists in namespace '{namespace}'. "
+                    "Use --force to replace it."
+                )
+        else:
+            raise
+
+
+# ────────────────────────────────── main ─────────────────────────────────
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate a secure random password; optionally save it as a Kubernetes Secret."
+    )
+    parser.add_argument("-l", "--length", type=int, default=10, help="Password length (default: 10)")
+    parser.add_argument("-n", "--namespace", help="Kubernetes namespace (default: current-context namespace)")
+    parser.add_argument("-s", "--secret", dest="secret_name", help="Name of the Secret to create")
+    parser.add_argument("--force", action="store_true", help="Replace an existing Secret if it exists")
+    args = parser.parse_args()
+
+    password = generate_password(args.length)
+    print(f"Generated password: {password}")
+
+    if not args.secret_name:
+        return  # No Secret requested.
+
+    namespace = args.namespace or get_default_namespace()
+    config.load_kube_config()  # Outside-cluster; switch to load_incluster_config() if desired
+    create_secret(namespace, args.secret_name, password, args.force)
+
+
+if __name__ == "__main__":
+    main()

--- a/kube/bin/requirements.txt
+++ b/kube/bin/requirements.txt
@@ -1,0 +1,2 @@
+requests
+kubernetes

--- a/kube/chart/.helmignore
+++ b/kube/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/kube/chart/Chart.yaml
+++ b/kube/chart/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: siren
+description: Deploy Siren on Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.2
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "3.0.4"

--- a/kube/chart/README.md
+++ b/kube/chart/README.md
@@ -1,0 +1,145 @@
+# siren
+
+Deploy Siren on Kubernetes
+
+## TL;DR
+```bash
+helm install <network>-ui  -f <network>-values.yaml ./siren
+```
+
+## Prerequisites
+- Kubernetes >= 1.27
+- Two Secrets with exact keys:
+  - API token secret → key **`apitoken`** (→ `API_TOKEN`)
+  - Session password secret → key **`password`** (→ `SESSION_PASSWORD`)
+
+## Configuration
+- `config.beaconUrl` (**required**): URL of your Beacon Node HTTP API (e.g. `http://lighthouse-beacon:5052`).
+- `config.validatorUrl` (**required**): URL of your Validator Client HTTP API (e.g. `http://lighthouse-validator:5062`).
+- `config.apiTokenSecretName` (**required**): Secret name holding key `apitoken`.
+- `config.passwordSecretName` (**required**): Secret name holding key `password`.
+
+> **Note:** This chart **does not** set defaults for `config.beaconUrl` or
+> `config.validatorUrl`. You must set them in your values at deploy time.
+
+## Install
+
+**From a local checkout**
+```bash
+helm install <network>-ui  -f values.yaml ./siren
+```
+
+**From a chart repo (Artifact Hub) — coming soon**
+```bash
+helm repo add k8ev <REPO_URL>
+helm repo update
+helm upgrade --install siren k8ev/siren -n eth-validator -f values.yaml
+```
+
+## Minimal values example
+```yaml
+config:
+  beaconUrl: "http://<beacon-service>:<port>"
+  validatorUrl: "http://<validator-service>:<port>"
+  debug: false
+  apiTokenSecretName: "siren-api"
+  passwordSecretName: "siren-session"
+```
+
+## Ingress (optional)
+
+If you want a public URL for the UI, enable the chart’s Ingress and set your domain.
+You **must** replace `\<your-domain.example.com\>` and adjust the controller class/annotations for your cluster.
+
+```yaml
+ingress:
+  enabled: true
+
+  # Prefer spec.ingressClassName when supported by your controller.
+  # Example values: "nginx", "traefik", "haproxy".
+  className: nginx
+
+  # Add any controller-specific annotations here.
+  annotations:
+    # If using cert-manager with a ClusterIssuer:
+    cert-manager.io/cluster-issuer: "letsencrypt"
+    # Some clusters still require the legacy class annotation:
+    kubernetes.io/ingress.class: "nginx"
+
+  hosts:
+    - host: <your-domain.example.com>
+      paths:
+        - path: /
+          pathType: Prefix
+
+  tls:
+    - secretName: <your-domain.example.com>-tls
+      hosts:
+        - <your-domain.example.com>
+```
+
+### Notes
+- Create an **A/AAAA** record for `<your-domain.example.com>` pointing to your Ingress controller’s external IP/hostname.
+- If you use a **namespaced Issuer** (not a ClusterIssuer), replace the annotation with: `cert-manager.io/issuer: "<issuer-name>"`.
+- Some controllers ignore `kubernetes.io/ingress.class` and only use `spec.ingressClassName` (`className` above). Keep whichever your cluster needs.
+- For multiple domains, add additional entries under `ingress.hosts` and `ingress.tls`.
+- If your app is served under a subpath, ensure your controller is configured for path rewrite/strip as needed.
+
+### Verify
+```bash
+kubectl -n <namespace> get ingress
+kubectl -n <namespace> describe ingress <release-name>
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| autoscaling.enabled | bool | `false` |  |
+| autoscaling.maxReplicas | int | `100` |  |
+| autoscaling.minReplicas | int | `1` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| config.apiTokenSecretName | string | `""` |  |
+| config.beaconUrl | string | `""` |  |
+| config.debug | bool | `false` |  |
+| config.passwordSecretName | string | `""` |  |
+| config.validatorUrl | string | `""` |  |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"Always"` |  |
+| image.repository | string | `"sigp/siren"` |  |
+| image.tag | string | `"v3.0.4"` |  |
+| imagePullSecrets | list | `[]` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.className | string | `""` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.hosts[0].host | string | `"chart-example.local"` |  |
+| ingress.hosts[0].paths[0].path | string | `"/"` |  |
+| ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
+| ingress.tls | list | `[]` |  |
+| livenessProbe.httpGet.path | string | `"/"` |  |
+| livenessProbe.httpGet.port | string | `"http"` |  |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext | object | `{}` |  |
+| readinessProbe.httpGet.path | string | `"/"` |  |
+| readinessProbe.httpGet.port | string | `"http"` |  |
+| replicaCount | int | `1` |  |
+| resources | object | `{}` |  |
+| securityContext | object | `{}` |  |
+| service.port | int | `3000` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.automount | bool | `true` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| tolerations | list | `[]` |  |
+| volumeMounts | list | `[]` |  |
+| volumes | list | `[]` |  |
+
+## Notes
+- Secret keys must match exactly: `apitoken` and `password`.
+- If you change the Secret names/keys, update `config.apiTokenSecretName` and/or
+  `config.passwordSecretName` accordingly.

--- a/kube/chart/README.md.gotmpl
+++ b/kube/chart/README.md.gotmpl
@@ -1,0 +1,99 @@
+# {{ template "chart.name" . }}
+
+{{ template "chart.description" . }}
+
+## TL;DR
+```bash
+helm install <network>-ui  -f <network>-values.yaml ./siren
+```
+
+## Prerequisites
+- Kubernetes >= 1.27
+- Two Secrets with exact keys:
+  - API token secret → key **`apitoken`** (→ `API_TOKEN`)
+  - Session password secret → key **`password`** (→ `SESSION_PASSWORD`)
+
+## Configuration
+- `config.beaconUrl` (**required**): URL of your Beacon Node HTTP API (e.g. `http://lighthouse-beacon:5052`).
+- `config.validatorUrl` (**required**): URL of your Validator Client HTTP API (e.g. `http://lighthouse-validator:5062`).
+- `config.apiTokenSecretName` (**required**): Secret name holding key `apitoken`.
+- `config.passwordSecretName` (**required**): Secret name holding key `password`.
+
+> **Note:** This chart **does not** set defaults for `config.beaconUrl` or
+> `config.validatorUrl`. You must set them in your values at deploy time.
+
+## Install
+
+**From a local checkout**
+```bash
+helm install <network>-ui  -f values.yaml ./siren
+```
+
+**From a chart repo (Artifact Hub) — coming soon**
+```bash
+helm repo add k8ev <REPO_URL>
+helm repo update
+helm upgrade --install siren k8ev/siren -n eth-validator -f values.yaml
+```
+
+## Minimal values example
+```yaml
+config:
+  beaconUrl: "http://<beacon-service>:<port>"
+  validatorUrl: "http://<validator-service>:<port>"
+  debug: false
+  apiTokenSecretName: "siren-api"
+  passwordSecretName: "siren-session"
+```
+
+## Ingress (optional)
+
+If you want a public URL for the UI, enable the chart’s Ingress and set your domain.
+You **must** replace `\<your-domain.example.com\>` and adjust the controller class/annotations for your cluster.
+
+```yaml
+ingress:
+  enabled: true
+
+  # Prefer spec.ingressClassName when supported by your controller.
+  # Example values: "nginx", "traefik", "haproxy".
+  className: nginx
+
+  # Add any controller-specific annotations here.
+  annotations:
+    # If using cert-manager with a ClusterIssuer:
+    cert-manager.io/cluster-issuer: "letsencrypt"
+    # Some clusters still require the legacy class annotation:
+    kubernetes.io/ingress.class: "nginx"
+
+  hosts:
+    - host: <your-domain.example.com>
+      paths:
+        - path: /
+          pathType: Prefix
+
+  tls:
+    - secretName: <your-domain.example.com>-tls
+      hosts:
+        - <your-domain.example.com>
+```
+
+### Notes
+- Create an **A/AAAA** record for `<your-domain.example.com>` pointing to your Ingress controller’s external IP/hostname.
+- If you use a **namespaced Issuer** (not a ClusterIssuer), replace the annotation with: `cert-manager.io/issuer: "<issuer-name>"`.
+- Some controllers ignore `kubernetes.io/ingress.class` and only use `spec.ingressClassName` (`className` above). Keep whichever your cluster needs.
+- For multiple domains, add additional entries under `ingress.hosts` and `ingress.tls`.
+- If your app is served under a subpath, ensure your controller is configured for path rewrite/strip as needed.
+
+### Verify
+```bash
+kubectl -n <namespace> get ingress
+kubectl -n <namespace> describe ingress <release-name>
+```
+
+{{ template "chart.valuesSection" . }}
+
+## Notes
+- Secret keys must match exactly: `apitoken` and `password`.
+- If you change the Secret names/keys, update `config.apiTokenSecretName` and/or
+  `config.passwordSecretName` accordingly.

--- a/kube/chart/templates/NOTES.txt
+++ b/kube/chart/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "siren.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "siren.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "siren.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "siren.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:3000 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/kube/chart/templates/_helpers.tpl
+++ b/kube/chart/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "siren.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "siren.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "siren.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "siren.labels" -}}
+helm.sh/chart: {{ include "siren.chart" . }}
+{{ include "siren.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "siren.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "siren.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "siren.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "siren.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/kube/chart/templates/configmap.yaml
+++ b/kube/chart/templates/configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "siren.fullname" . }}-config
+  labels:
+    {{- include "siren.labels" . | nindent 4 }}
+data:
+  {{- if .Values.config.beaconUrl }}
+  BEACON_URL: {{ .Values.config.beaconUrl }}
+  {{- end }}
+  {{- if .Values.config.validatorUrl }}
+  VALIDATOR_URL: {{ .Values.config.validatorUrl }}
+  {{- end }}
+  SSL_ENABLED: "false"
+  DEBUG: "{{ .Values.config.debug }}"

--- a/kube/chart/templates/deployment.yaml
+++ b/kube/chart/templates/deployment.yaml
@@ -1,0 +1,92 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "siren.fullname" . }}
+  labels:
+    {{- include "siren.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "siren.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "siren.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "siren.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: SESSION_PASSWORD
+              valueFrom:
+                 secretKeyRef:
+                   name: {{ .Values.config.passwordSecretName }}
+                   key: password
+            - name: API_TOKEN
+              valueFrom:
+                 secretKeyRef:
+                   name: {{ .Values.config.apiTokenSecretName }}
+                   key: apitoken
+          envFrom:
+            - configMapRef:
+                name: {{ include "siren.fullname" . }}-config
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/kube/chart/templates/hpa.yaml
+++ b/kube/chart/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "siren.fullname" . }}
+  labels:
+    {{- include "siren.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "siren.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/kube/chart/templates/ingress.yaml
+++ b/kube/chart/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "siren.fullname" . }}
+  labels:
+    {{- include "siren.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "siren.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/kube/chart/templates/service.yaml
+++ b/kube/chart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "siren.fullname" . }}
+  labels:
+    {{- include "siren.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "siren.selectorLabels" . | nindent 4 }}

--- a/kube/chart/templates/serviceaccount.yaml
+++ b/kube/chart/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "siren.serviceAccountName" . }}
+  labels:
+    {{- include "siren.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/kube/chart/templates/tests/test-connection.yaml
+++ b/kube/chart/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "siren.fullname" . }}-test-connection"
+  labels:
+    {{- include "siren.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "siren.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/kube/chart/values.yaml
+++ b/kube/chart/values.yaml
@@ -1,0 +1,130 @@
+# Default values for siren.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: sigp/siren
+  # This sets the pull policy for images.
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "v3.0.4"
+
+# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  type: ClusterIP
+  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+  port: 3000
+
+# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+config:
+  beaconUrl: ""
+  validatorUrl: ""
+  debug: false
+  apiTokenSecretName: ""
+  passwordSecretName: ""


### PR DESCRIPTION
Support for deploying siren on kubernetes
- copy of upstream waTeim/k8ev-kit/siren with artifacthub annotations stripped out
- helm chart named `siren`
- 2 python scripts to assist in creating kubernetes secrets that siren uses, also requirements.txt to satisfy dependencies
  - `genpw.py`: generate a password for siren session and store it as a kubernetes secret
  - `create_secret.py`:  generalised create secret -- can be used to store contents of api-token.txt
- helm-docs generated README documenting use/configuration
