### PR TITLE
 Do not enable "secure" flag for cookies if SSL is disabled

### DIFF
--- a/app/api/authenticate/route.ts
+++ b/app/api/authenticate/route.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 import { NextResponse } from 'next/server'
-import { BACKEND_URL, NODE_ENV } from '../../../src/constants/envars'
+import { BACKEND_URL, NODE_ENV, SSL_ENABLED } from '../../../src/constants/envars'
 
 export async function POST(req: Request) {
   try {
@@ -17,7 +17,7 @@ export async function POST(req: Request) {
 
     response.cookies.set('session-token', token, {
       httpOnly: true,
-      secure: NODE_ENV === 'production',
+      secure: NODE_ENV === 'production' && SSL_ENABLED,
       path: '/',
       sameSite: 'strict',
     } as any)

--- a/src/constants/envars.ts
+++ b/src/constants/envars.ts
@@ -2,3 +2,4 @@ export const BACKEND_URL = process.env.BACKEND_URL || 'http://127.0.0.1:3001'
 export const BACKEND_PORT = process.env.BACKEND_PORT || 3001
 export const PORT = process.env.PORT || 3300
 export const NODE_ENV = process.env.NODE_ENV
+export const SSL_ENABLED = process.env.SSL_ENABLED === 'true'


### PR DESCRIPTION
For people who don't want to use HTTPS flag "secure" should not be set

<img width="758" height="58" alt="image" src="https://github.com/user-attachments/assets/f50a1af5-1fc9-4c66-9112-0b099ff0e396" />
