### PR TITLE
Metrics for non mainnet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ API_TOKEN=get-it-from-'.lighthouse/validators/api-token.txt'
 SESSION_PASSWORD=default-siren-password
 SSL_ENABLED=true
 DEBUG=false
+DISABLE_HEALTH_CHECKS=false
 # don't change these when building the docker image, only change when running outside of docker
 PORT=3300
 BACKEND_URL=http://127.0.0.1:3001

--- a/backend/src/node/node.service.ts
+++ b/backend/src/node/node.service.ts
@@ -27,7 +27,7 @@ export class NodeService {
         'specs',
       )) as BeaconNodeSpecResults;
       const isMainnet = CONFIG_NAME?.toLowerCase() === 'mainnet';
-      
+
       return this.utilsService.fetchFromCache(
         'nodeHealth',
         (SECONDS_PER_SLOT * 1000) / 2,
@@ -68,22 +68,30 @@ export class NodeService {
           const totalDiskFree = formatGigBytes(disk_bytes_free);
 
           const diskThresholds = isMainnet
-            ? { synced: { success: 300, warning: 200 }, syncing: { success: 100, warning: 50 } }
-            : { synced: { success: 150, warning: 100 }, syncing: { success: 50, warning: 25 } };
+            ? {
+                synced: { success: 300, warning: 200 },
+                syncing: { success: 100, warning: 50 },
+              }
+            : {
+                synced: { success: 50, warning: 25 },
+                syncing: { success: 50, warning: 25 },
+              };
 
           const diskStatus = {
             synced: this.disableHealthChecks
               ? StatusColor.SUCCESS
               : totalDiskFree > diskThresholds.synced.success
                 ? StatusColor.SUCCESS
-                : totalDiskFree >= diskThresholds.synced.warning && totalDiskFree < diskThresholds.synced.success
+                : totalDiskFree >= diskThresholds.synced.warning &&
+                    totalDiskFree < diskThresholds.synced.success
                   ? StatusColor.WARNING
                   : StatusColor.ERROR,
             syncing: this.disableHealthChecks
               ? StatusColor.SUCCESS
               : totalDiskFree > diskThresholds.syncing.success
                 ? StatusColor.SUCCESS
-                : totalDiskFree >= diskThresholds.syncing.warning && totalDiskFree < diskThresholds.syncing.success
+                : totalDiskFree >= diskThresholds.syncing.warning &&
+                    totalDiskFree < diskThresholds.syncing.success
                   ? StatusColor.WARNING
                   : StatusColor.ERROR,
           };
@@ -104,7 +112,8 @@ export class NodeService {
             ? StatusColor.SUCCESS
             : totalMemoryFree >= ramThresholds.success
               ? StatusColor.SUCCESS
-              : totalMemoryFree > ramThresholds.warning && totalMemoryFree < ramThresholds.success
+              : totalMemoryFree > ramThresholds.warning &&
+                  totalMemoryFree < ramThresholds.success
                 ? StatusColor.WARNING
                 : StatusColor.ERROR;
 
@@ -112,13 +121,14 @@ export class NodeService {
 
           const cpuThresholds = isMainnet
             ? { success: 80, warning: 90 }
-            : { success: 40, warning: 45 };
+            : { success: 80, warning: 90 };
 
           const cpuStatus = this.disableHealthChecks
             ? StatusColor.SUCCESS
             : sys_loadavg_1 <= cpuThresholds.success
               ? StatusColor.SUCCESS
-              : sys_loadavg_1 > cpuThresholds.success && sys_loadavg_1 < cpuThresholds.warning
+              : sys_loadavg_1 > cpuThresholds.success &&
+                  sys_loadavg_1 < cpuThresholds.warning
                 ? StatusColor.WARNING
                 : StatusColor.ERROR;
 

--- a/backend/src/node/node.service.ts
+++ b/backend/src/node/node.service.ts
@@ -19,12 +19,15 @@ export class NodeService {
   private validatorUrl = process.env.VALIDATOR_URL;
   private apiToken = process.env.API_TOKEN;
   private beaconUrl = process.env.BEACON_URL;
+  private disableHealthChecks = process.env.DISABLE_HEALTH_CHECKS === 'true';
 
   async fetchNodeHealth(): Promise<Diagnostics> {
     try {
-      const { SECONDS_PER_SLOT } = (await this.cacheManager.get(
+      const { SECONDS_PER_SLOT, CONFIG_NAME } = (await this.cacheManager.get(
         'specs',
       )) as BeaconNodeSpecResults;
+      const isMainnet = CONFIG_NAME?.toLowerCase() === 'mainnet';
+      
       return this.utilsService.fetchFromCache(
         'nodeHealth',
         (SECONDS_PER_SLOT * 1000) / 2,
@@ -64,17 +67,23 @@ export class NodeService {
           const totalDiskSpace = formatGigBytes(disk_bytes_total);
           const totalDiskFree = formatGigBytes(disk_bytes_free);
 
+          const diskThresholds = isMainnet
+            ? { synced: { success: 300, warning: 200 }, syncing: { success: 100, warning: 50 } }
+            : { synced: { success: 150, warning: 100 }, syncing: { success: 50, warning: 25 } };
+
           const diskStatus = {
-            synced:
-              totalDiskFree > 300
+            synced: this.disableHealthChecks
+              ? StatusColor.SUCCESS
+              : totalDiskFree > diskThresholds.synced.success
                 ? StatusColor.SUCCESS
-                : totalDiskFree >= 200 && totalDiskFree < 300
+                : totalDiskFree >= diskThresholds.synced.warning && totalDiskFree < diskThresholds.synced.success
                   ? StatusColor.WARNING
                   : StatusColor.ERROR,
-            syncing:
-              totalDiskFree > 100
+            syncing: this.disableHealthChecks
+              ? StatusColor.SUCCESS
+              : totalDiskFree > diskThresholds.syncing.success
                 ? StatusColor.SUCCESS
-                : totalDiskFree >= 50 && totalDiskFree < 100
+                : totalDiskFree >= diskThresholds.syncing.warning && totalDiskFree < diskThresholds.syncing.success
                   ? StatusColor.WARNING
                   : StatusColor.ERROR,
           };
@@ -87,19 +96,29 @@ export class NodeService {
 
           const totalMemoryFree = totalMemory - usedMemory;
 
-          const ramStatus =
-            totalMemoryFree >= 3
+          const ramThresholds = isMainnet
+            ? { success: 3, warning: 1 }
+            : { success: 1.5, warning: 0.5 };
+
+          const ramStatus = this.disableHealthChecks
+            ? StatusColor.SUCCESS
+            : totalMemoryFree >= ramThresholds.success
               ? StatusColor.SUCCESS
-              : totalMemoryFree > 1 && totalMemoryFree < 3
+              : totalMemoryFree > ramThresholds.warning && totalMemoryFree < ramThresholds.success
                 ? StatusColor.WARNING
                 : StatusColor.ERROR;
 
           const cpuUtilization = sys_loadavg_1.toFixed(1);
 
-          const cpuStatus =
-            sys_loadavg_1 <= 80
+          const cpuThresholds = isMainnet
+            ? { success: 80, warning: 90 }
+            : { success: 40, warning: 45 };
+
+          const cpuStatus = this.disableHealthChecks
+            ? StatusColor.SUCCESS
+            : sys_loadavg_1 <= cpuThresholds.success
               ? StatusColor.SUCCESS
-              : sys_loadavg_1 > 80 && sys_loadavg_1 < 90
+              : sys_loadavg_1 > cpuThresholds.success && sys_loadavg_1 < cpuThresholds.warning
                 ? StatusColor.WARNING
                 : StatusColor.ERROR;
 

--- a/src/mocks/beaconSpec.ts
+++ b/src/mocks/beaconSpec.ts
@@ -15,7 +15,7 @@ export const mockDiagnostics = {
   diskUtilization: 0,
   totalDiskFree: 123,
   diskStatus: {
-    synced: StatusColor.ERROR,
+    synced: StatusColor.WARNING,
     syncing: StatusColor.SUCCESS,
   },
   totalMemory: 123,
@@ -31,11 +31,11 @@ export const mockDiagnostics = {
     validator: '10M 0S',
   },
   healthCondition: {
-    synced: DiagnosticRate.POOR,
+    synced: DiagnosticRate.FAIR,
     syncing: DiagnosticRate.GOOD,
   },
   overallHealthStatus: {
-    synced: StatusColor.ERROR,
+    synced: StatusColor.WARNING,
     syncing: StatusColor.SUCCESS,
   },
 }

--- a/src/mocks/beaconSpec.ts
+++ b/src/mocks/beaconSpec.ts
@@ -15,7 +15,7 @@ export const mockDiagnostics = {
   diskUtilization: 0,
   totalDiskFree: 123,
   diskStatus: {
-    synced: StatusColor.WARNING,
+    synced: StatusColor.SUCCESS,
     syncing: StatusColor.SUCCESS,
   },
   totalMemory: 123,
@@ -31,11 +31,11 @@ export const mockDiagnostics = {
     validator: '10M 0S',
   },
   healthCondition: {
-    synced: DiagnosticRate.FAIR,
+    synced: DiagnosticRate.GOOD,
     syncing: DiagnosticRate.GOOD,
   },
   overallHealthStatus: {
-    synced: StatusColor.WARNING,
+    synced: StatusColor.SUCCESS,
     syncing: StatusColor.SUCCESS,
   },
 }


### PR DESCRIPTION
This resolves #419. 

There are a second lower set of criteria that applies to the health of the node for non mainnet networks. 

You can also set these all to green by adding `DISABLE_HEALTH_CHECKS=true` to the .env variable. 