### PR TITLE
Display and modify fee recipient on validator dashboard

### DIFF
--- a/app/api/update-fee-recipient/route.ts
+++ b/app/api/update-fee-recipient/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server'
+import getReqAuthToken from '../../../utilities/getReqAuthToken'
+import { updateFeeRecipient } from '../validator'
+
+export async function PUT(req: Request) {
+  try {
+    const data = await req.json()
+    const token = getReqAuthToken(req)
+
+    const res = await updateFeeRecipient(token, data)
+    return NextResponse.json(res, { status: 200 })
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Failed to update fee recipient'
+    return NextResponse.json({ error: errorMessage }, { status: 500 })
+  }
+}

--- a/app/api/validator.ts
+++ b/app/api/validator.ts
@@ -29,3 +29,9 @@ export const fetchPartialWithdrawals = async (token: string) =>
 
 export const fetchPendingDeposits = async (token: string) =>
   await fetchFromApi(`${BACKEND_URL}/validator/pending-deposits`, token)
+
+export const updateFeeRecipient = async (token: string, data: any) =>
+  await fetchFromApi(`${BACKEND_URL}/validator/fee-recipient`, token, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  })

--- a/backend/src/validator/validator.controller.ts
+++ b/backend/src/validator/validator.controller.ts
@@ -121,4 +121,10 @@ export class ValidatorController {
   async getFeeRecipient(@Param('pubkey') pubkey: string) {
     return this.validatorService.fetchFeeRecipient(pubkey);
   }
+
+  @Put('fee-recipient')
+  @UseGuards(AuthGuard)
+  async updateFeeRecipient(@Body() feeRecipientData) {
+    return this.validatorService.updateFeeRecipient(feeRecipientData);
+  }
 }

--- a/backend/src/validator/validator.controller.ts
+++ b/backend/src/validator/validator.controller.ts
@@ -116,4 +116,9 @@ export class ValidatorController {
     await this.validatorService.importValidatorAliases(aliases);
     return { success: true };
   }
+
+  @Get('fee-recipient/:pubkey')
+  async getFeeRecipient(@Param('pubkey') pubkey: string) {
+    return this.validatorService.fetchFeeRecipient(pubkey);
+  }
 }

--- a/backend/src/validator/validator.service.ts
+++ b/backend/src/validator/validator.service.ts
@@ -82,7 +82,13 @@ export class ValidatorService {
               Number(a.index) - Number(b.index),
           ) as BeaconValidatorResult[];
 
-          return sortedStates.map(({ validator, index, status, balance }) => {
+          // Fetch fee recipients for all validators
+          const feeRecipientPromises = sortedStates.map(({ validator }) =>
+            this.fetchFeeRecipient(validator.pubkey).catch(() => ({ data: { ethaddress: '' } }))
+          );
+          const feeRecipients = await Promise.all(feeRecipientPromises);
+
+          return sortedStates.map(({ validator, index, status, balance }, idx) => {
             const {
               pubkey,
               effective_balance,
@@ -113,6 +119,7 @@ export class ValidatorService {
               missed: 0,
               attested: 0,
               aggregated: 0,
+              feeRecipient: feeRecipients[idx]?.data?.ethaddress || undefined,
             };
           });
         },
@@ -372,6 +379,20 @@ export class ValidatorService {
     } catch (e) {
       console.error(e);
       throwServerError('Unable to import validator aliases');
+    }
+  }
+
+  async fetchFeeRecipient(pubkey: string): Promise<{ data: { ethaddress: string } }> {
+    try {
+      const { data } = await this.utilsService.sendHttpRequest({
+        url: `${this.validatorUrl}/eth/v1/validator/${pubkey}/feerecipient`,
+        config: this.config,
+      });
+
+      return data;
+    } catch (e) {
+      console.error(e);
+      return { data: { ethaddress: '' } };
     }
   }
 }

--- a/backend/src/validator/validator.service.ts
+++ b/backend/src/validator/validator.service.ts
@@ -404,4 +404,40 @@ export class ValidatorService {
       return { data: { ethaddress: '' } };
     }
   }
+
+  async updateFeeRecipient(data: any) {
+    try {
+      const { status } = await this.utilsService.sendHttpRequest({
+        url: `${this.validatorUrl}/eth/v1/validator/${data.pubKey}/feerecipient`,
+        method: 'POST',
+        config: {
+          data: JSON.stringify({ ethaddress: data.feeRecipient }),
+          headers: {
+            'Content-Type': 'application/json',
+            ...this.config.headers,
+          },
+        },
+      });
+
+      if (status === 202 || status === 200) {
+        await this.activityService.storeActivity(
+          '',
+          data.pubKey,
+          ActivityType.FEE_RECIPIENT,
+          Status.SUCCESS,
+        );
+      }
+
+      return status;
+    } catch (e) {
+      console.error(e);
+      await this.activityService.storeActivity(
+        '',
+        data.pubKey,
+        ActivityType.FEE_RECIPIENT,
+        Status.ERROR,
+      );
+      throwServerError('Unable to update fee recipient');
+    }
+  }
 }

--- a/src/components/ActivityHistory/ActivityText.tsx
+++ b/src/components/ActivityHistory/ActivityText.tsx
@@ -63,6 +63,10 @@ const ActivityText: React.FC<ActivityTextProps> = ({
         pubKey: formatEthAddress(pubKey),
       }),
     },
+    [ActivityType.FEE_RECIPIENT]: {
+      key: `updateFeeRecipient.${isError ? 'errorText' : 'text'}`,
+      values: () => ({ pubKey: formatEthAddress(pubKey) }),
+    },
   }[type]
 
   if (!config) return null

--- a/src/components/EditableFeeRecipient/EditableFeeRecipient.tsx
+++ b/src/components/EditableFeeRecipient/EditableFeeRecipient.tsx
@@ -6,6 +6,8 @@ import isEthereumAddress from '../../../utilities/isEthereumAddress'
 import useUiMode from '../../hooks/useUiMode'
 import { ToastType } from '../../types'
 import AuthPrompt from '../AuthPrompt/AuthPrompt'
+import Button, { ButtonFace } from '../Button/Button'
+import RodalModal from '../RodalModal/RodalModal'
 import Tooltip from '../ToolTip/Tooltip'
 import Typography from '../Typography/Typography'
 
@@ -27,6 +29,8 @@ const EditableFeeRecipient: FC<EditableFeeRecipientProps> = ({
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [isAuth, setAuth] = useState(false)
+  const [showConfirmation, setShowConfirmation] = useState(false)
+  const [isConfirmed, setIsConfirmed] = useState(false)
 
   useEffect(() => {
     setEditValue(feeRecipient || '')
@@ -55,7 +59,18 @@ const EditableFeeRecipient: FC<EditableFeeRecipientProps> = ({
     }
 
     setError(null)
+    setShowConfirmation(true)
+  }
+
+  const handleConfirmationProceed = () => {
+    setShowConfirmation(false)
+    setIsConfirmed(false)
     setAuth(true)
+  }
+
+  const handleConfirmationCancel = () => {
+    setShowConfirmation(false)
+    setIsConfirmed(false)
   }
 
   const updateFeeRecipient = async (password: string) => {
@@ -114,6 +129,51 @@ const EditableFeeRecipient: FC<EditableFeeRecipientProps> = ({
 
   return (
     <>
+      <RodalModal
+        isVisible={showConfirmation}
+        onClose={handleConfirmationCancel}
+        styles={{ maxWidth: '500px' }}
+      >
+        <div className='p-6'>
+          <Typography type='text-subtitle1' color='text-dark500' className='mb-4'>
+            {t('validatorEdit.feeRecipient.confirmTitle', 'Confirm fee recipient update')}
+          </Typography>
+          <div className='space-y-4'>
+            <Typography type='text-caption1' color='text-dark500' className='leading-relaxed'>
+              {t(
+                'validatorEdit.feeRecipient.confirmMessage',
+                'Updating fee recipient in Siren will replace the fee recipients set in the validator client and/or beacon node using --suggested-fee-recipient',
+              )}
+            </Typography>
+            <div className='flex items-start gap-2 mt-4'>
+              <input
+                type='checkbox'
+                id='confirm-checkbox'
+                checked={isConfirmed}
+                onChange={(e) => setIsConfirmed(e.target.checked)}
+                className='mt-1 w-4 h-4 text-primary bg-gray-100 border-gray-300 rounded focus:ring-primary dark:focus:ring-primary dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
+              />
+              <label htmlFor='confirm-checkbox' className='cursor-pointer'>
+                <Typography type='text-caption1' color='text-dark500'>
+                  {t('validatorEdit.feeRecipient.confirmCheckbox', 'I understand and proceed')}
+                </Typography>
+              </label>
+            </div>
+          </div>
+          <div className='flex gap-2 justify-end mt-6'>
+            <Button type={ButtonFace.TERTIARY} onClick={handleConfirmationCancel}>
+              {t('common.cancel', 'Cancel')}
+            </Button>
+            <Button
+              type={ButtonFace.SECONDARY}
+              isDisabled={!isConfirmed}
+              onClick={handleConfirmationProceed}
+            >
+              {t('common.continue', 'Continue')}
+            </Button>
+          </div>
+        </div>
+      </RodalModal>
       <AuthPrompt
         isLoading={isLoading}
         mode={mode}

--- a/src/components/EditableFeeRecipient/EditableFeeRecipient.tsx
+++ b/src/components/EditableFeeRecipient/EditableFeeRecipient.tsx
@@ -1,0 +1,186 @@
+import { FC, useState, useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import displayToast from '../../../utilities/displayToast'
+import formatEthAddress from '../../../utilities/formatEthAddress'
+import isEthereumAddress from '../../../utilities/isEthereumAddress'
+import useUiMode from '../../hooks/useUiMode'
+import { ToastType } from '../../types'
+import AuthPrompt from '../AuthPrompt/AuthPrompt'
+import Tooltip from '../ToolTip/Tooltip'
+import Typography from '../Typography/Typography'
+
+export interface EditableFeeRecipientProps {
+  feeRecipient: string | undefined
+  pubKey: string
+  onUpdate?: (newFeeRecipient: string) => void
+}
+
+const EditableFeeRecipient: FC<EditableFeeRecipientProps> = ({
+  feeRecipient,
+  pubKey,
+  onUpdate,
+}) => {
+  const { t } = useTranslation()
+  const { mode } = useUiMode()
+  const [isEditing, setIsEditing] = useState(false)
+  const [editValue, setEditValue] = useState(feeRecipient || '')
+  const [error, setError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [isAuth, setAuth] = useState(false)
+
+  useEffect(() => {
+    setEditValue(feeRecipient || '')
+  }, [feeRecipient])
+
+  const handleEdit = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    setIsEditing(true)
+    setError(null)
+  }
+
+  const handleCancel = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    setIsEditing(false)
+    setEditValue(feeRecipient || '')
+    setError(null)
+  }
+
+  const handleSave = (e: React.MouseEvent) => {
+    e.stopPropagation()
+
+    // Validate Ethereum address
+    if (!isEthereumAddress(editValue)) {
+      setError('Invalid Ethereum address format')
+      return
+    }
+
+    setError(null)
+    setAuth(true)
+  }
+
+  const updateFeeRecipient = async (password: string) => {
+    setIsLoading(true)
+    setAuth(false)
+
+    try {
+      const response = await fetch('/api/update-fee-recipient', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+        body: JSON.stringify({
+          pubKey,
+          feeRecipient: editValue,
+          password,
+        }),
+      })
+
+      setIsLoading(false)
+
+      if (response.ok) {
+        displayToast(t('validatorEdit.feeRecipient.successUpdate'), ToastType.SUCCESS)
+        setIsEditing(false)
+        onUpdate?.(editValue)
+      } else {
+        const data = await response.json().catch(() => ({}))
+        const errorMessage =
+          typeof data.error === 'string'
+            ? data.error
+            : data.message || t('validatorEdit.feeRecipient.errorUpdate')
+        setError(errorMessage)
+        displayToast(t('validatorEdit.feeRecipient.errorUpdate'), ToastType.ERROR)
+      }
+    } catch (err) {
+      setIsLoading(false)
+      console.error('Error updating fee recipient:', err)
+      const errorMessage =
+        err instanceof Error ? err.message : t('validatorEdit.feeRecipient.unexpectedError')
+      setError(errorMessage)
+      displayToast(t('validatorEdit.feeRecipient.unexpectedError'), ToastType.ERROR)
+    }
+  }
+
+  const closeAuth = () => setAuth(false)
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setEditValue(e.target.value)
+    setError(null)
+  }
+
+  const handleInputClick = (e: React.MouseEvent) => {
+    e.stopPropagation()
+  }
+
+  return (
+    <>
+      <AuthPrompt
+        isLoading={isLoading}
+        mode={mode}
+        onClose={closeAuth}
+        isVisible={isAuth}
+        onSubmit={updateFeeRecipient}
+      />
+      {isEditing ? (
+        <div className='flex flex-col items-center gap-1' onClick={(e) => e.stopPropagation()}>
+          <div className='flex items-center gap-1'>
+            <input
+              type='text'
+              value={editValue}
+              onChange={handleInputChange}
+              onClick={handleInputClick}
+              placeholder='0x...'
+              disabled={isLoading}
+              className='w-32 px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-dark750 text-dark500 dark:text-white focus:outline-none focus:border-primary'
+            />
+            <button
+              onClick={handleSave}
+              disabled={isLoading}
+              className='px-2 py-1 text-xs bg-success text-white rounded hover:bg-green-600 disabled:opacity-50'
+            >
+              <i className='bi-check-lg' />
+            </button>
+            <button
+              onClick={handleCancel}
+              disabled={isLoading}
+              className='px-2 py-1 text-xs bg-error text-white rounded hover:bg-red-600 disabled:opacity-50'
+            >
+              <i className='bi-x-lg' />
+            </button>
+          </div>
+          {error && (
+            <Typography type='text-tiny' color='text-error' className='text-center'>
+              {error}
+            </Typography>
+          )}
+        </div>
+      ) : (
+        <div className='flex items-center gap-2 group cursor-pointer' onClick={handleEdit}>
+          {feeRecipient ? (
+            <Tooltip
+              id={`fee-${pubKey}`}
+              place='top-start'
+              style={{ fontSize: '12px' }}
+              text={feeRecipient}
+            >
+              <Typography
+                color='text-dark500'
+                type='text-caption1'
+                className='text-center w-fit mx-auto'
+              >
+                {formatEthAddress(feeRecipient)}
+              </Typography>
+            </Tooltip>
+          ) : (
+            <Typography color='text-dark500' type='text-caption1' className='text-center'>
+              -
+            </Typography>
+          )}
+          <i className='bi-pencil text-xs text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity' />
+        </div>
+      )}
+    </>
+  )
+}
+
+export default EditableFeeRecipient

--- a/src/components/EditableFeeRecipient/EditableFeeRecipient.tsx
+++ b/src/components/EditableFeeRecipient/EditableFeeRecipient.tsx
@@ -191,7 +191,7 @@ const EditableFeeRecipient: FC<EditableFeeRecipientProps> = ({
               onClick={handleInputClick}
               placeholder='0x...'
               disabled={isLoading}
-              className='w-32 px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-dark750 text-dark500 dark:text-white focus:outline-none focus:border-primary'
+              className='w-80 px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-dark750 text-dark500 dark:text-white focus:outline-none focus:border-primary font-mono'
             />
             <button
               onClick={handleSave}

--- a/src/components/EditableFeeRecipient/EditableFeeRecipient.tsx
+++ b/src/components/EditableFeeRecipient/EditableFeeRecipient.tsx
@@ -30,7 +30,6 @@ const EditableFeeRecipient: FC<EditableFeeRecipientProps> = ({
   const [isLoading, setIsLoading] = useState(false)
   const [isAuth, setAuth] = useState(false)
   const [showConfirmation, setShowConfirmation] = useState(false)
-  const [isConfirmed, setIsConfirmed] = useState(false)
 
   useEffect(() => {
     setEditValue(feeRecipient || '')
@@ -64,13 +63,11 @@ const EditableFeeRecipient: FC<EditableFeeRecipientProps> = ({
 
   const handleConfirmationProceed = () => {
     setShowConfirmation(false)
-    setIsConfirmed(false)
     setAuth(true)
   }
 
   const handleConfirmationCancel = () => {
     setShowConfirmation(false)
-    setIsConfirmed(false)
   }
 
   const updateFeeRecipient = async (password: string) => {
@@ -145,31 +142,13 @@ const EditableFeeRecipient: FC<EditableFeeRecipientProps> = ({
                 'Updating fee recipient in Siren will replace the fee recipients set in the validator client and/or beacon node using --suggested-fee-recipient',
               )}
             </Typography>
-            <div className='flex items-start gap-2 mt-4'>
-              <input
-                type='checkbox'
-                id='confirm-checkbox'
-                checked={isConfirmed}
-                onChange={(e) => setIsConfirmed(e.target.checked)}
-                className='mt-1 w-4 h-4 text-primary bg-gray-100 border-gray-300 rounded focus:ring-primary dark:focus:ring-primary dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600'
-              />
-              <label htmlFor='confirm-checkbox' className='cursor-pointer'>
-                <Typography type='text-caption1' color='text-dark500'>
-                  {t('validatorEdit.feeRecipient.confirmCheckbox', 'I understand and proceed')}
-                </Typography>
-              </label>
-            </div>
           </div>
           <div className='flex gap-2 justify-end mt-6'>
             <Button type={ButtonFace.TERTIARY} onClick={handleConfirmationCancel}>
               {t('common.cancel', 'Cancel')}
             </Button>
-            <Button
-              type={ButtonFace.SECONDARY}
-              isDisabled={!isConfirmed}
-              onClick={handleConfirmationProceed}
-            >
-              {t('common.continue', 'Continue')}
+            <Button type={ButtonFace.SECONDARY} onClick={handleConfirmationProceed}>
+              {t('common.proceed', 'Proceed')}
             </Button>
           </div>
         </div>

--- a/src/components/ValidatorTable/ValidatorRow.tsx
+++ b/src/components/ValidatorTable/ValidatorRow.tsx
@@ -22,6 +22,7 @@ import { selectBeaconChaBaseUrl } from '../../recoil/selectors/selectBeaconChaBa
 import { ValAliases } from '../../types'
 import { ValidatorInfo } from '../../types/validator'
 import DisabledTooltip from '../DisabledTooltip/DisabledTooltip'
+import EditableFeeRecipient from '../EditableFeeRecipient/EditableFeeRecipient'
 import IdenticonIcon from '../IdenticonIcon/IdenticonIcon'
 import StatusIcon from '../StatusIcon/StatusIcon'
 import Tooltip from '../ToolTip/Tooltip'
@@ -39,12 +40,12 @@ const ValidatorRow: FC<ValidatorRowProps> = ({ validator, view }) => {
   const { t } = useTranslation()
   const router = useRouter()
   const [isReady, setReady] = useState(false)
+  const [currentFeeRecipient, setCurrentFeeRecipient] = useState(validator.feeRecipient)
   const processingValidators = useRecoilValue(processingBlsValidators)
   const setActiveValidatorId = useSetRecoilState(activeValidatorId)
   const setIsEditValidator = useSetRecoilState(isEditValidator)
   const setValDetail = useSetRecoilState(isValidatorDetail)
-  const { pubKey, index, balance, rewards, status, withdrawalAddress, name, feeRecipient } =
-    validator
+  const { pubKey, index, balance, rewards, status, withdrawalAddress, name } = validator
   const rewardColor = formatBalanceColor(rewards)
   const baseBeaconChaUrl = useRecoilValue(selectBeaconChaBaseUrl)
   const valHrefBase = `/dashboard/validators?id=${index}`
@@ -70,6 +71,10 @@ const ValidatorRow: FC<ValidatorRowProps> = ({ validator, view }) => {
     setReady(true)
   }, [])
 
+  useEffect(() => {
+    setCurrentFeeRecipient(validator.feeRecipient)
+  }, [validator.feeRecipient])
+
   // Use API aliases if available, fallback to localStorage for migration
   const currentAliases = aliases || localAliases
   const valName = useValidatorName(validator, currentAliases)
@@ -86,8 +91,15 @@ const ValidatorRow: FC<ValidatorRowProps> = ({ validator, view }) => {
   }
 
   const viewDetail = (e: MouseEvent<HTMLTableRowElement>) => {
-    if (e.target instanceof Element && e.target.closest('button')) {
-      return
+    if (e.target instanceof Element) {
+      // Don't trigger if clicking buttons, inputs, or modal overlays
+      if (
+        e.target.closest('button') ||
+        e.target.closest('input') ||
+        e.target.closest('.rodal-dialog')
+      ) {
+        return
+      }
     }
 
     if (view === 'full') {
@@ -165,26 +177,11 @@ const ValidatorRow: FC<ValidatorRowProps> = ({ validator, view }) => {
         />
       </th>
       <th className='px-2'>
-        {feeRecipient ? (
-          <Tooltip
-            id={`fee-${pubKey}`}
-            place='top-start'
-            style={{ fontSize: '12px' }}
-            text={feeRecipient}
-          >
-            <Typography
-              color='text-dark500'
-              type='text-caption1'
-              className='text-center w-fit mx-auto'
-            >
-              {formatEthAddress(feeRecipient)}
-            </Typography>
-          </Tooltip>
-        ) : (
-          <Typography color='text-dark500' type='text-caption1' className='text-center'>
-            -
-          </Typography>
-        )}
+        <EditableFeeRecipient
+          feeRecipient={currentFeeRecipient}
+          pubKey={pubKey}
+          onUpdate={setCurrentFeeRecipient}
+        />
       </th>
       <th className='border-r-style500 px-4'>
         <div className='flex items-center mx-auto justify-between flex-wrap w-full max-w-[100px]'>

--- a/src/components/ValidatorTable/ValidatorRow.tsx
+++ b/src/components/ValidatorTable/ValidatorRow.tsx
@@ -43,7 +43,8 @@ const ValidatorRow: FC<ValidatorRowProps> = ({ validator, view }) => {
   const setActiveValidatorId = useSetRecoilState(activeValidatorId)
   const setIsEditValidator = useSetRecoilState(isEditValidator)
   const setValDetail = useSetRecoilState(isValidatorDetail)
-  const { pubKey, index, balance, rewards, status, withdrawalAddress, name, feeRecipient } = validator
+  const { pubKey, index, balance, rewards, status, withdrawalAddress, name, feeRecipient } =
+    validator
   const rewardColor = formatBalanceColor(rewards)
   const baseBeaconChaUrl = useRecoilValue(selectBeaconChaBaseUrl)
   const valHrefBase = `/dashboard/validators?id=${index}`
@@ -165,8 +166,17 @@ const ValidatorRow: FC<ValidatorRowProps> = ({ validator, view }) => {
       </th>
       <th className='px-2'>
         {feeRecipient ? (
-          <Tooltip id={`fee-${pubKey}`} place='top-start' style={{ fontSize: '12px' }} text={feeRecipient}>
-            <Typography color='text-dark500' type='text-caption1' className='text-center w-fit mx-auto'>
+          <Tooltip
+            id={`fee-${pubKey}`}
+            place='top-start'
+            style={{ fontSize: '12px' }}
+            text={feeRecipient}
+          >
+            <Typography
+              color='text-dark500'
+              type='text-caption1'
+              className='text-center w-fit mx-auto'
+            >
               {formatEthAddress(feeRecipient)}
             </Typography>
           </Tooltip>

--- a/src/components/ValidatorTable/ValidatorRow.tsx
+++ b/src/components/ValidatorTable/ValidatorRow.tsx
@@ -43,7 +43,7 @@ const ValidatorRow: FC<ValidatorRowProps> = ({ validator, view }) => {
   const setActiveValidatorId = useSetRecoilState(activeValidatorId)
   const setIsEditValidator = useSetRecoilState(isEditValidator)
   const setValDetail = useSetRecoilState(isValidatorDetail)
-  const { pubKey, index, balance, rewards, status, withdrawalAddress, name } = validator
+  const { pubKey, index, balance, rewards, status, withdrawalAddress, name, feeRecipient } = validator
   const rewardColor = formatBalanceColor(rewards)
   const baseBeaconChaUrl = useRecoilValue(selectBeaconChaBaseUrl)
   const valHrefBase = `/dashboard/validators?id=${index}`
@@ -162,6 +162,19 @@ const ValidatorRow: FC<ValidatorRowProps> = ({ validator, view }) => {
           withdrawalAddress={withdrawalAddress}
           id={pubKey}
         />
+      </th>
+      <th className='px-2'>
+        {feeRecipient ? (
+          <Tooltip id={`fee-${pubKey}`} place='top-start' style={{ fontSize: '12px' }} text={feeRecipient}>
+            <Typography color='text-dark500' type='text-caption1' className='text-center w-fit mx-auto'>
+              {formatEthAddress(feeRecipient)}
+            </Typography>
+          </Tooltip>
+        ) : (
+          <Typography color='text-dark500' type='text-caption1' className='text-center'>
+            -
+          </Typography>
+        )}
       </th>
       <th className='border-r-style500 px-4'>
         <div className='flex items-center mx-auto justify-between flex-wrap w-full max-w-[100px]'>

--- a/src/components/ValidatorTable/ValidatorTable.tsx
+++ b/src/components/ValidatorTable/ValidatorTable.tsx
@@ -155,6 +155,16 @@ const ValidatorTable: FC<ValidatorTableProps> = ({
                         {t('withdrawalAddress')}
                       </Typography>
                     </th>
+                    <th>
+                      <Typography
+                        color='text-dark500'
+                        type='text-tiny'
+                        isUpperCase
+                        className='text-center'
+                      >
+                        FEE RECIPIENT
+                      </Typography>
+                    </th>
                     <th className={`${view === 'partial' ? 'border-r-style500' : ''} pl-2`}>
                       <Typography
                         color='text-dark500'

--- a/src/locales/translations/en-US.json
+++ b/src/locales/translations/en-US.json
@@ -733,6 +733,11 @@
       "unexpectedError": "An unexpected error occurred while updating graffiti. Please try again.",
       "successUpdate": "Successfully updated validator graffiti",
       "errorUpdate": "Unable to update graffiti, be sure that \"--graffiti-file\" flag is not set"
+    },
+    "feeRecipient": {
+      "unexpectedError": "An unexpected error occurred while updating fee recipient. Please try again.",
+      "successUpdate": "Successfully updated fee recipient",
+      "errorUpdate": "Unable to update fee recipient. Please check the address format and try again."
     }
   },
   "deviceSelect": {
@@ -837,6 +842,12 @@
         "errorTitle": "Failed Partial Withdrawal Request",
         "text": "Request made to partial withdrawal <span>{{amount}}</span>ETH from validator: <span>{{pubKey}}</span> with transaction hash: of <span>{{txHash}}</span>. Click here to review the transaction details on Etherscan.",
         "errorText": "Request made to partial withdrawal <span>{{amount}}</span>ETH from validator: <span>{{pubKey}}</span> with transaction hash: of <span>{{txHash}}</span> was unsuccessful. Click here to review the transaction details on Etherscan."
+      },
+      "updateFeeRecipient": {
+        "title": "Fee Recipient Updated",
+        "errorTitle": "Failed Fee Recipient Update",
+        "text": "Validator with pubkey: <span>{{pubKey}}</span> fee recipient updated successfully. Review the changes in the Validator Management view.",
+        "errorText": "Siren was unable to update the fee recipient for validator with pubkey: <span>{{pubKey}}</span>. Please check the address format and try again."
       }
     }
   },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -214,6 +214,7 @@ export enum ActivityType {
   GRAFFITI = 'GRAFFITI',
   PARTIAL_WITHDRAWAL = 'PARTIAL_WITHDRAWAL',
   CONSOLIDATION = 'CONSOLIDATION',
+  FEE_RECIPIENT = 'FEE_RECIPIENT',
 }
 
 export type ActivityResponse = {

--- a/src/types/validator.ts
+++ b/src/types/validator.ts
@@ -42,6 +42,7 @@ export type ValidatorInfo = {
   missed: number
   attested: number
   aggregated: number
+  feeRecipient?: string
 }
 
 export type ValidatorBalanceInfo = {

--- a/utilities/getActivityIcon.ts
+++ b/utilities/getActivityIcon.ts
@@ -12,6 +12,8 @@ const getActivityIcon = (type: ActivityType) => {
       return 'bi-intersect'
     case ActivityType.PARTIAL_WITHDRAWAL:
       return 'bi-send'
+    case ActivityType.FEE_RECIPIENT:
+      return 'bi-wallet2'
     default:
       return 'bi-clock-history'
   }

--- a/utilities/getActivityTitleKey.ts
+++ b/utilities/getActivityTitleKey.ts
@@ -6,6 +6,7 @@ const ACTIVITY_KEY: Record<ActivityType, string> = {
   [ActivityType.GRAFFITI]: 'updateGraffiti',
   [ActivityType.CONSOLIDATION]: 'consolidation',
   [ActivityType.PARTIAL_WITHDRAWAL]: 'partialWithdrawal',
+  [ActivityType.FEE_RECIPIENT]: 'updateFeeRecipient',
 }
 
 const getActivityTitleKey = (type: ActivityType, isError: boolean) => {

--- a/utilities/isEthereumAddress.ts
+++ b/utilities/isEthereumAddress.ts
@@ -1,0 +1,14 @@
+/**
+ * Validates if a string is a valid Ethereum address
+ * @param address - The address to validate
+ * @returns true if valid Ethereum address, false otherwise
+ */
+const isEthereumAddress = (address: string): boolean => {
+  if (!address) return false
+
+  // Check if it starts with 0x and is 42 characters long
+  const ethAddressRegex = /^0x[a-fA-F0-9]{40}$/
+  return ethAddressRegex.test(address)
+}
+
+export default isEthereumAddress

--- a/utilities/isEthereumAddress.ts
+++ b/utilities/isEthereumAddress.ts
@@ -1,14 +1,10 @@
-/**
- * Validates if a string is a valid Ethereum address
- * @param address - The address to validate
- * @returns true if valid Ethereum address, false otherwise
- */
+import { isAddress } from 'ethers'
+
+// Validates if the input fee recipient is a valid Ethereum address
+
 const isEthereumAddress = (address: string): boolean => {
   if (!address) return false
-
-  // Check if it starts with 0x and is 42 characters long
-  const ethAddressRegex = /^0x[a-fA-F0-9]{40}$/
-  return ethAddressRegex.test(address)
+  return isAddress(address)
 }
 
 export default isEthereumAddress


### PR DESCRIPTION
Before:
<img width="1778" height="747" alt="before" src="https://github.com/user-attachments/assets/e7c19672-c637-4c0d-a96a-ac7c4cf477b1" />

After: 
<img width="1778" height="747" alt="after" src="https://github.com/user-attachments/assets/9d340e48-9138-405b-a1ce-1214bf39b0ce" />


This is the first step: to display the fee recipient, about #230 

Regarding modifying it, the `/lighthouse/patch` endpoint does not have the fee recipient as an input parameter:
https://github.com/sigp/lighthouse/blob/e5b4983d6baf85770fe4539a565d8a2dd462bc53/common/eth2/src/lighthouse_vc/http_client.rs#L417-L426

so we can't use this endpoint (or have to modify Lighthouse). 

Maybe the key manager API? I assume this will modify the fee recipient in the VC, and the `validator_definitions.yml` file on-the-go? Not sure about this. This probably needs a closer look

Update: add the feature to modify the fee recipient, see comment below