### PR TITLE
Fix ERROR logs not showing in Log Level filter

### DIFF
--- a/backend/src/logs/logs.service.ts
+++ b/backend/src/logs/logs.service.ts
@@ -19,7 +19,7 @@ export class LogsService {
   constructor(
     @InjectModel(Log)
     private logRepository: typeof Log,
-  ) {}
+  ) { }
 
   private isDebug = process.env.DEBUG === 'true';
 
@@ -31,6 +31,18 @@ export class LogsService {
 
   private clientManager = new ClientManager();
 
+
+  // Normalizes Lighthouse log level to Siren's LogLevels
+  private normalizeLogLevel(level: any): LogLevels {
+    // Lighthouse sends 'ERROR' but Siren uses 'ERRO'
+    if (level === 'ERROR') {
+      return LogLevels.ERRO;
+    }
+
+    // Return the level as-is if it's already a valid LogLevels value
+    return level as LogLevels;
+  }
+
   /**
    * Transforms the new Lighthouse log format to the expected SSELog format
    */
@@ -39,7 +51,7 @@ export class LogsService {
     const { message, ...otherFields } = fields;
 
     return {
-      level,
+      level: this.normalizeLogLevel(level),
       msg: message,
       service: target,
       time,
@@ -142,8 +154,11 @@ export class LogsService {
             if (this.isLighthouseFormat(rawData)) {
               newData = this.transformLighthouseLog(rawData);
             } else {
-              // Handle legacy format
+              // Handle legacy format - normalize the level if needed
               newData = rawData as SSELog;
+              if (newData.level) {
+                newData.level = this.normalizeLogLevel(newData.level);
+              }
             }
 
             const { level } = newData;

--- a/src/utilities/transformLighthouseLog.ts
+++ b/src/utilities/transformLighthouseLog.ts
@@ -1,4 +1,15 @@
-import { SSELog, LighthouseLog } from '../types'
+import { SSELog, LighthouseLog, LogLevels } from '../types'
+
+// Normalizes Lighthouse log level to Siren's LogLevels
+export function normalizeLogLevel(level: any): LogLevels {
+  // Lighthouse sends 'ERROR' but Siren uses 'ERRO'
+  if (level === 'ERROR') {
+    return LogLevels.ERRO;
+  }
+
+  // Return the level as-is if it's already a valid LogLevels value
+  return level as LogLevels;
+}
 
 /**
  * Transforms the new Lighthouse log format to the expected SSELog format
@@ -8,7 +19,7 @@ export function transformLighthouseLog(rawLog: LighthouseLog): SSELog {
   const { message, ...otherFields } = fields
 
   return {
-    level,
+    level: normalizeLogLevel(level),
     msg: message,
     service: target,
     time,
@@ -41,5 +52,12 @@ export function normalizeLogData(rawData: any): SSELog {
   }
 
   // Handle legacy format or already normalized data
-  return rawData as SSELog
+  const normalizedData = rawData as SSELog
+
+  // Normalize the level if it exists
+  if (normalizedData.level) {
+    normalizedData.level = normalizeLogLevel(normalizedData.level)
+  }
+
+  return normalizedData
 }


### PR DESCRIPTION
This is because Lighthouse now uses `ERROR` but Siren uses `ERRO` in the filter. 

Tested the fix and `ERROR` logs now showing in Log Level filter in Siren