### PR TITLE
Fix fee recipient update password error

### DIFF
--- a/app/api/update-fee-recipient/route.ts
+++ b/app/api/update-fee-recipient/route.ts
@@ -11,6 +11,8 @@ export async function PUT(req: Request) {
     return NextResponse.json(res, { status: 200 })
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Failed to update fee recipient'
-    return NextResponse.json({ error: errorMessage }, { status: 500 })
+    // Check if it's a 401 authentication error
+    const status = errorMessage.includes('Status: 401') ? 401 : 500
+    return NextResponse.json({ error: errorMessage }, { status })
   }
 }

--- a/src/components/EditableFeeRecipient/EditableFeeRecipient.tsx
+++ b/src/components/EditableFeeRecipient/EditableFeeRecipient.tsx
@@ -95,13 +95,20 @@ const EditableFeeRecipient: FC<EditableFeeRecipientProps> = ({
         setIsEditing(false)
         onUpdate?.(editValue)
       } else {
-        const data = await response.json().catch(() => ({}))
-        const errorMessage =
-          typeof data.error === 'string'
-            ? data.error
-            : data.message || t('validatorEdit.feeRecipient.errorUpdate')
-        setError(errorMessage)
-        displayToast(t('validatorEdit.feeRecipient.errorUpdate'), ToastType.ERROR)
+        // Check if it's a password authentication error (401)
+        if (response.status === 401) {
+          const errorMessage = t('validatorEdit.feeRecipient.incorrectPassword')
+          setError(errorMessage)
+          displayToast(errorMessage, ToastType.ERROR)
+        } else {
+          const data = await response.json().catch(() => ({}))
+          const errorMessage =
+            typeof data.error === 'string'
+              ? data.error
+              : data.message || t('validatorEdit.feeRecipient.errorUpdate')
+          setError(errorMessage)
+          displayToast(t('validatorEdit.feeRecipient.errorUpdate'), ToastType.ERROR)
+        }
       }
     } catch (err) {
       setIsLoading(false)

--- a/src/locales/translations/en-US.json
+++ b/src/locales/translations/en-US.json
@@ -740,7 +740,10 @@
     "feeRecipient": {
       "unexpectedError": "An unexpected error occurred while updating fee recipient. Please try again.",
       "successUpdate": "Successfully updated fee recipient",
-      "errorUpdate": "Unable to update fee recipient. Please check the address format and try again."
+      "errorUpdate": "Unable to update fee recipient. Please check the address format and try again.",
+      "incorrectPassword": "Incorrect password. Please try again.",
+      "confirmTitle": "Confirm fee recipient update",
+      "confirmMessage": "Updating fee recipient in Siren will replace the fee recipients set in the validator client and/or beacon node using --suggested-fee-recipient"
     }
   },
   "deviceSelect": {


### PR DESCRIPTION
Fix a bug when updating fee recipient - when an incorrect password is entered, it displayed a wrong message:
`unable to update fee recipient, please check the ethereum format and try again`

After the fix, it is now displaying "incorrect password" window

Before:

<img width="939" height="436" alt="Screenshot from 2025-11-10 16-00-26" src="https://github.com/user-attachments/assets/ff53c305-4cf0-4620-a245-c933d31693f5" />

After:

<img width="939" height="436" alt="Screenshot from 2025-11-10 16-00-58" src="https://github.com/user-attachments/assets/3fe3b3ff-90ad-4a1d-911a-6726c7555f8d" />

