### PR TITLE
fix: no-vals

### DIFF
--- a/backend/src/tasks/tasks.service.ts
+++ b/backend/src/tasks/tasks.service.ts
@@ -382,6 +382,12 @@ export class TasksService implements OnApplicationBootstrap {
         },
       },
     });
+
+    if(!data?.data.length) {
+      await this.cacheManager.set('validators', [], 0);
+      return;
+    }
+
     const validatorKeys = data.data
       .map((validator: LighthouseValidatorResult) => validator.voting_pubkey)
       .join(',');


### PR DESCRIPTION
Problem:

Tried running siren with no validators and ran into errors running the backend. This PR address those issues allowing for empty state so users can add validators with siren.